### PR TITLE
feat : 메시지 히스토리 조회

### DIFF
--- a/src/main/java/com/example/easybooking/chat/ChatRoomReader.java
+++ b/src/main/java/com/example/easybooking/chat/ChatRoomReader.java
@@ -4,16 +4,14 @@ import com.example.easybooking.chat.domain.ChatRoom;
 import com.example.easybooking.chat.domain.Message;
 import com.example.easybooking.chat.dto.response.ChatRoomListResponse;
 import com.example.easybooking.chat.repository.ChatRoomRepository;
-import com.example.easybooking.shop.domain.Shop;
 import com.example.easybooking.shop.ShopReader;
+import com.example.easybooking.shop.domain.Shop;
 import com.example.easybooking.user.UserReader;
 import com.example.easybooking.user.domain.User;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
@@ -33,48 +31,68 @@ public class ChatRoomReader {
     }
 
     public List<ChatRoomListResponse> getChatRoomList(Long userId) {
-        List<ChatRoom> chatRooms = getChatRooms(userId);
-        List<ChatRoomListResponse> chatRoomListResponses = new ArrayList<>();
-        if(chatRooms.isEmpty()) return chatRoomListResponses;
-        for (ChatRoom chatRoom : chatRooms) {
-            chatRoomListResponses.add(from(userId,chatRoom));
-        }
-        return chatRoomListResponses;
+        List<ChatRoom> chatRooms = chatRoomRepository.findChatRooms(userId);
+
+        return chatRooms.stream()
+                .map(chatRoom -> convertToChatRoomListResponse(userId, chatRoom))
+                .toList();
     }
 
-    public List<ChatRoom> getChatRooms(Long userId) {
-        return chatRoomRepository.findChatRooms(userId);
-    }
-
-    public ChatRoomListResponse from(Long userId,ChatRoom chatRoom) {
-        Message lastMessage = null;
-        if (chatRoom.getLastMessageId() != null && chatRoom.getLastMessageId() > 0) {
-            lastMessage = messageReader.read(chatRoom.getLastMessageId());
-        }
-
-        Long lastReadMessageId = chatRoom.getLastReadMessageId(userId);
-        int unreadCount = messageReader.countUnreadMessages(
-                chatRoom.getId(),
-                lastReadMessageId,
-                userId  // 내가 보낸 메시지는 제외
-        );
-
-        Long otherUserId = chatRoom.getOwnerId().equals(userId)
-                ? chatRoom.getCustomerId()
-                : chatRoom.getOwnerId();
-        User otherUser = userReader.read(otherUserId);
-
+    private ChatRoomListResponse convertToChatRoomListResponse(Long userId, ChatRoom chatRoom) {
+        LastMessageInfo lastMessageInfo = getLastMessageInfo(chatRoom);
+        int unreadCount = calculateUnreadCount(userId, chatRoom);
+        OtherUserInfo otherUserInfo = getOtherUserInfo(userId, chatRoom);
         Shop shop = shopReader.read(chatRoom.getShopId());
 
         return ChatRoomListResponse.builder()
                 .chatRoomId(chatRoom.getId())
                 .shopId(chatRoom.getShopId())
                 .shopBusinessName(shop.getBusinessName())
-                .otherUserId(otherUserId)
-                .otherUserName(otherUser.getName())
-                .lastMessageContent(lastMessage != null ? lastMessage.getContent() : null)
+                .otherUserId(otherUserInfo.userId())
+                .otherUserName(otherUserInfo.userName())
+                .lastMessageSenderId(lastMessageInfo.senderId())
+                .lastMessageContent(lastMessageInfo.content())
                 .lastMessageAt(chatRoom.getLastMessageAt())
                 .unreadCount(unreadCount)
                 .build();
+    }
+
+    private LastMessageInfo getLastMessageInfo(ChatRoom chatRoom) {
+        if (chatRoom.getLastMessageId() == null || chatRoom.getLastMessageId() == 0) {
+            return new LastMessageInfo(null, null);
+        }
+
+        Message lastMessage = messageReader.read(chatRoom.getLastMessageId());
+        return new LastMessageInfo(
+                lastMessage.getSenderId(),
+                lastMessage.getContent()
+        );
+    }
+
+    private int calculateUnreadCount(Long userId, ChatRoom chatRoom) {
+        Long lastReadMessageId = chatRoom.getLastReadMessageId(userId);
+        return messageReader.countUnreadMessages(
+                chatRoom.getId(),
+                lastReadMessageId,
+                userId
+        );
+    }
+
+    private OtherUserInfo getOtherUserInfo(Long userId, ChatRoom chatRoom) {
+        Long otherUserId = determineOtherUserId(userId, chatRoom);
+        User otherUser = userReader.read(otherUserId);
+        return new OtherUserInfo(otherUserId, otherUser.getName());
+    }
+
+    private Long determineOtherUserId(Long userId, ChatRoom chatRoom) {
+        return chatRoom.getOwnerId().equals(userId)
+                ? chatRoom.getCustomerId()
+                : chatRoom.getOwnerId();
+    }
+
+    private record LastMessageInfo(Long senderId, String content) {
+    }
+
+    private record OtherUserInfo(Long userId, String userName) {
     }
 }

--- a/src/main/java/com/example/easybooking/chat/MessageReader.java
+++ b/src/main/java/com/example/easybooking/chat/MessageReader.java
@@ -1,37 +1,33 @@
 package com.example.easybooking.chat;
 
 import com.example.easybooking.chat.domain.Message;
-import com.example.easybooking.chat.dto.response.MessageResponse;
 import com.example.easybooking.chat.repository.MessageRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 public class MessageReader {
     private final MessageRepository messageRepository;
 
-    public Message read(Long messageId){
+    public Message read(Long messageId) {
         return messageRepository.findById(messageId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메시지입니다."));
     }
 
-    public List<MessageResponse> readMessages(Long chatRoomId, Long cursorId, int size) {
+    public List<Message> readMessages(Long chatRoomId, Long cursorId, int size) {
         List<Message> messages;
         if (cursorId == null) {
             messages = messageRepository.findLatestMessages(chatRoomId, size);
         } else {
             messages = messageRepository.findMessagesBeforeCursor(chatRoomId, cursorId, size);
         }
-        return messages.stream()
-                .map(MessageResponse::from)
-                .toList();
+        return messages;
     }
 
 
-    public int countUnreadMessages(Long chatRoomId, Long lastMessageId,Long userId) {
+    public int countUnreadMessages(Long chatRoomId, Long lastMessageId, Long userId) {
         return messageRepository.countUnreadMessages(chatRoomId, lastMessageId, userId);
     }
 }

--- a/src/main/java/com/example/easybooking/chat/MessageReader.java
+++ b/src/main/java/com/example/easybooking/chat/MessageReader.java
@@ -1,5 +1,6 @@
 package com.example.easybooking.chat;
 
+import com.example.easybooking.chat.domain.ChatRoom;
 import com.example.easybooking.chat.domain.Message;
 import com.example.easybooking.chat.repository.MessageRepository;
 import java.util.List;
@@ -16,12 +17,13 @@ public class MessageReader {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메시지입니다."));
     }
 
-    public List<Message> readMessages(Long chatRoomId, Long cursorId, int size) {
+    public List<Message> readMessages(ChatRoom chatRoom, Long cursorId, int size, Long userId) {
         List<Message> messages;
         if (cursorId == null) {
-            messages = messageRepository.findLatestMessages(chatRoomId, size);
+            messages = messageRepository.findLatestMessages(chatRoom.getId(), size);
+            chatRoom.updateLastReadMessageId(messages.get(0).getId(), userId);
         } else {
-            messages = messageRepository.findMessagesBeforeCursor(chatRoomId, cursorId, size);
+            messages = messageRepository.findMessagesBeforeCursor(chatRoom.getId(), cursorId, size);
         }
         return messages;
     }

--- a/src/main/java/com/example/easybooking/chat/MessageReader.java
+++ b/src/main/java/com/example/easybooking/chat/MessageReader.java
@@ -2,6 +2,7 @@ package com.example.easybooking.chat;
 
 import com.example.easybooking.chat.domain.ChatRoom;
 import com.example.easybooking.chat.domain.Message;
+import com.example.easybooking.chat.repository.ChatRoomRepository;
 import com.example.easybooking.chat.repository.MessageRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MessageReader {
     private final MessageRepository messageRepository;
+    private final ChatRoomRepository chatRoomRepository;
 
     public Message read(Long messageId) {
         return messageRepository.findById(messageId)
@@ -22,6 +24,7 @@ public class MessageReader {
         if (cursorId == null) {
             messages = messageRepository.findLatestMessages(chatRoom.getId(), size);
             chatRoom.updateLastReadMessageId(messages.get(0).getId(), userId);
+            chatRoomRepository.save(chatRoom);
         } else {
             messages = messageRepository.findMessagesBeforeCursor(chatRoom.getId(), cursorId, size);
         }
@@ -29,7 +32,7 @@ public class MessageReader {
     }
 
 
-    public int countUnreadMessages(Long chatRoomId, Long lastMessageId, Long userId) {
-        return messageRepository.countUnreadMessages(chatRoomId, lastMessageId, userId);
+    public int countUnreadMessages(Long chatRoomId, Long lastReadMessageId, Long userId) {
+        return messageRepository.countUnreadMessages(chatRoomId, lastReadMessageId, userId);
     }
 }

--- a/src/main/java/com/example/easybooking/chat/MessageReader.java
+++ b/src/main/java/com/example/easybooking/chat/MessageReader.java
@@ -1,9 +1,12 @@
 package com.example.easybooking.chat;
 
 import com.example.easybooking.chat.domain.Message;
+import com.example.easybooking.chat.dto.response.MessageResponse;
 import com.example.easybooking.chat.repository.MessageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -14,6 +17,19 @@ public class MessageReader {
         return messageRepository.findById(messageId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 메시지입니다."));
     }
+
+    public List<MessageResponse> readMessages(Long chatRoomId, Long cursorId, int size) {
+        List<Message> messages;
+        if (cursorId == null) {
+            messages = messageRepository.findLatestMessages(chatRoomId, size);
+        } else {
+            messages = messageRepository.findMessagesBeforeCursor(chatRoomId, cursorId, size);
+        }
+        return messages.stream()
+                .map(MessageResponse::from)
+                .toList();
+    }
+
 
     public int countUnreadMessages(Long chatRoomId, Long lastMessageId,Long userId) {
         return messageRepository.countUnreadMessages(chatRoomId, lastMessageId, userId);

--- a/src/main/java/com/example/easybooking/chat/MessageWriter.java
+++ b/src/main/java/com/example/easybooking/chat/MessageWriter.java
@@ -23,7 +23,12 @@ public class MessageWriter {
     @Transactional
     public MessageResponse save(Long chatRoomId, Long userId, ChatMessageRequest request) {
         User user = userReader.read(userId);
-        Message message = Message.create(chatRoomId,user.getId(), request.getMessage());
+        Message message = Message.create(
+                chatRoomId,
+                user.getId(),
+                user.getName(),
+                request.getMessage()
+        );
         messageRepository.save(message);
         ChatRoom chatRoom = chatRoomReader.read(chatRoomId);
         chatRoom.updateLastMessage(message.getId(), LocalDateTime.now());

--- a/src/main/java/com/example/easybooking/chat/MessageWriter.java
+++ b/src/main/java/com/example/easybooking/chat/MessageWriter.java
@@ -25,14 +25,13 @@ public class MessageWriter {
         User user = userReader.read(userId);
         Message message = Message.create(
                 chatRoomId,
-                user.getId(),
-                user.getName(),
+                userId,
                 request.getMessage()
         );
         messageRepository.save(message);
         ChatRoom chatRoom = chatRoomReader.read(chatRoomId);
         chatRoom.updateLastMessage(message.getId(), LocalDateTime.now());
-        MessageResponse response = MessageResponse.from(message);
+        MessageResponse response = MessageResponse.from(message, user.getName());
         return response;
     }
 }

--- a/src/main/java/com/example/easybooking/chat/MessageWriter.java
+++ b/src/main/java/com/example/easybooking/chat/MessageWriter.java
@@ -4,7 +4,7 @@ import com.example.easybooking.chat.domain.ChatRoom;
 import com.example.easybooking.chat.domain.Message;
 import com.example.easybooking.chat.repository.MessageRepository;
 import com.example.easybooking.chat.dto.request.ChatMessageRequest;
-import com.example.easybooking.chat.dto.response.ChatMessageResponse;
+import com.example.easybooking.chat.dto.response.MessageResponse;
 import com.example.easybooking.user.UserReader;
 import com.example.easybooking.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -21,13 +21,13 @@ public class MessageWriter {
     private final ChatRoomReader chatRoomReader;
 
     @Transactional
-    public ChatMessageResponse save(Long chatRoomId, Long userId, ChatMessageRequest request) {
+    public MessageResponse save(Long chatRoomId, Long userId, ChatMessageRequest request) {
         User user = userReader.read(userId);
         Message message = Message.create(chatRoomId,user.getId(), request.getMessage());
         messageRepository.save(message);
         ChatRoom chatRoom = chatRoomReader.read(chatRoomId);
         chatRoom.updateLastMessage(message.getId(), LocalDateTime.now());
-        ChatMessageResponse response = ChatMessageResponse.from(message);
+        MessageResponse response = MessageResponse.from(message);
         return response;
     }
 }

--- a/src/main/java/com/example/easybooking/chat/config/JwtChannelInterceptor.java
+++ b/src/main/java/com/example/easybooking/chat/config/JwtChannelInterceptor.java
@@ -62,8 +62,7 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
                 }
             } else {
                 log.warn("Authorization 헤더가 없거나 형식이 잘못되었습니다.");
-                // 개발 환경에서는 토큰 없이도 허용 (선택사항)
-                // throw new IllegalArgumentException("인증 토큰이 필요합니다.");
+                throw new IllegalArgumentException("인증 토큰이 필요합니다.");
             }
         }
 

--- a/src/main/java/com/example/easybooking/chat/domain/ChatRoom.java
+++ b/src/main/java/com/example/easybooking/chat/domain/ChatRoom.java
@@ -65,7 +65,7 @@ public class ChatRoom {
         this.lastMessageAt = sentAt;
     }
 
-    public void updateLastReadMessageId(Long userId, Long messageId) {
+    public void updateLastReadMessageId(Long messageId, Long userId) {
         if (this.ownerId.equals(userId)) {
             this.ownerLastReadMessageId = messageId;
         } else if (this.customerId.equals(userId)) {

--- a/src/main/java/com/example/easybooking/chat/domain/ChatRoom.java
+++ b/src/main/java/com/example/easybooking/chat/domain/ChatRoom.java
@@ -1,9 +1,12 @@
 package com.example.easybooking.chat.domain;
 
-import jakarta.persistence.*;
-import lombok.Getter;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import lombok.Getter;
 
 @Entity
 @Getter
@@ -60,6 +63,14 @@ public class ChatRoom {
     public void updateLastMessage(Long messageId, LocalDateTime sentAt) {
         this.lastMessageId = messageId;
         this.lastMessageAt = sentAt;
+    }
+
+    public void updateLastReadMessageId(Long userId, Long messageId) {
+        if (this.ownerId.equals(userId)) {
+            this.ownerLastReadMessageId = messageId;
+        } else if (this.customerId.equals(userId)) {
+            this.customerLastReadMessageId = messageId;
+        }
     }
 
     public boolean isParticipant(Long userId) {

--- a/src/main/java/com/example/easybooking/chat/domain/Message.java
+++ b/src/main/java/com/example/easybooking/chat/domain/Message.java
@@ -20,8 +20,6 @@ public class Message {
     @Column(nullable = false)
     private Long senderId;
 
-    @Column(nullable = false)
-    private String senderName;
 
     @Column(columnDefinition = "TEXT")
     private String content;
@@ -29,11 +27,10 @@ public class Message {
     @Column(nullable = false, updatable = false)
     private LocalDateTime sentAt;
 
-    public static Message create(Long chatRoomId,Long senderId,String senderName, String content) {
+    public static Message create(Long chatRoomId,Long senderId, String content) {
         Message message = new Message();
         message.chatRoomId = chatRoomId;
         message.senderId = senderId;
-        message.senderName = senderName;
         message.content = content;
         message.sentAt = LocalDateTime.now();
         return message;

--- a/src/main/java/com/example/easybooking/chat/domain/Message.java
+++ b/src/main/java/com/example/easybooking/chat/domain/Message.java
@@ -20,16 +20,20 @@ public class Message {
     @Column(nullable = false)
     private Long senderId;
 
+    @Column(nullable = false)
+    private String senderName;
+
     @Column(columnDefinition = "TEXT")
     private String content;
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime sentAt;
 
-    public static Message create(Long chatRoomId,Long senderId, String content) {
+    public static Message create(Long chatRoomId,Long senderId,String senderName, String content) {
         Message message = new Message();
         message.chatRoomId = chatRoomId;
         message.senderId = senderId;
+        message.senderName = senderName;
         message.content = content;
         message.sentAt = LocalDateTime.now();
         return message;

--- a/src/main/java/com/example/easybooking/chat/dto/response/ChatRoomListResponse.java
+++ b/src/main/java/com/example/easybooking/chat/dto/response/ChatRoomListResponse.java
@@ -1,11 +1,10 @@
 package com.example.easybooking.chat.dto.response;
 
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -19,6 +18,7 @@ public class ChatRoomListResponse {
     private Long otherUserId;
     private String otherUserName;
 
+    private Long lastMessageSenderId;
     private String lastMessageContent;
     private LocalDateTime lastMessageAt;
 

--- a/src/main/java/com/example/easybooking/chat/dto/response/MessageResponse.java
+++ b/src/main/java/com/example/easybooking/chat/dto/response/MessageResponse.java
@@ -20,11 +20,11 @@ public class MessageResponse {
     private LocalDateTime sentAt;
     private Long roomId;
 
-    public static MessageResponse from(Message message) {
+    public static MessageResponse from(Message message,String senderName) {
         return MessageResponse.builder()
                 .messageId(message.getId())
                 .senderId(message.getSenderId())
-                .senderName(message.getSenderName())
+                .senderName(senderName)
                 .message(message.getContent())
                 .sentAt(message.getSentAt())
                 .roomId(message.getChatRoomId())

--- a/src/main/java/com/example/easybooking/chat/dto/response/MessageResponse.java
+++ b/src/main/java/com/example/easybooking/chat/dto/response/MessageResponse.java
@@ -20,10 +20,11 @@ public class MessageResponse {
     private LocalDateTime sentAt;
     private Long roomId;
 
-    public static MessageResponse from(Message message){
+    public static MessageResponse from(Message message) {
         return MessageResponse.builder()
                 .messageId(message.getId())
                 .senderId(message.getSenderId())
+                .senderName(message.getSenderName())
                 .message(message.getContent())
                 .sentAt(message.getSentAt())
                 .roomId(message.getChatRoomId())

--- a/src/main/java/com/example/easybooking/chat/dto/response/MessageResponse.java
+++ b/src/main/java/com/example/easybooking/chat/dto/response/MessageResponse.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Getter
 @Builder
-public class ChatMessageResponse {
+public class MessageResponse {
     private Long messageId;
     private Long senderId;
     private String senderName;
@@ -20,8 +20,8 @@ public class ChatMessageResponse {
     private LocalDateTime sentAt;
     private Long roomId;
 
-    public static ChatMessageResponse from(Message message){
-        return ChatMessageResponse.builder()
+    public static MessageResponse from(Message message){
+        return MessageResponse.builder()
                 .messageId(message.getId())
                 .senderId(message.getSenderId())
                 .message(message.getContent())

--- a/src/main/java/com/example/easybooking/chat/presentation/ChatController.java
+++ b/src/main/java/com/example/easybooking/chat/presentation/ChatController.java
@@ -2,7 +2,7 @@ package com.example.easybooking.chat.presentation;
 
 import com.example.easybooking.chat.service.ChatService;
 import com.example.easybooking.chat.dto.request.ChatMessageRequest;
-import com.example.easybooking.chat.dto.response.ChatMessageResponse;
+import com.example.easybooking.chat.dto.response.MessageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
@@ -21,7 +21,7 @@ public class ChatController {
 
     @MessageMapping("/chat/{chatRoomId}")
     @SendTo("/topic/chat/{chatRoomId}")
-    public ChatMessageResponse sendMessage(
+    public MessageResponse sendMessage(
             @DestinationVariable Long chatRoomId,
             @Payload @Valid ChatMessageRequest request,
             Principal principal) {

--- a/src/main/java/com/example/easybooking/chat/presentation/MesssageController.java
+++ b/src/main/java/com/example/easybooking/chat/presentation/MesssageController.java
@@ -1,0 +1,31 @@
+package com.example.easybooking.chat.presentation;
+
+import com.example.easybooking.auth.AuthenticatedUser;
+import com.example.easybooking.auth.RequireAuthenticatedUser;
+import com.example.easybooking.chat.dto.response.MessageResponse;
+import com.example.easybooking.chat.service.MessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/chat/rooms/{chatRoomId}/messages")
+public class MesssageController {
+
+    private final MessageService messageService;
+
+    @GetMapping
+    public ResponseEntity<List<MessageResponse>> getMessageHistory(
+            @PathVariable Long chatRoomId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "50") int size,
+            @RequireAuthenticatedUser AuthenticatedUser user) {
+        return ResponseEntity.ok(
+                messageService.getMessageHistory(chatRoomId, user.getUserId(), cursor, size)
+        );
+    }
+
+}

--- a/src/main/java/com/example/easybooking/chat/repository/MessageRepository.java
+++ b/src/main/java/com/example/easybooking/chat/repository/MessageRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MessageRepository extends JpaRepository<Message,Long> {
     @Query("SELECT COUNT(m) FROM Message m " +
@@ -17,4 +19,20 @@ public interface MessageRepository extends JpaRepository<Message,Long> {
             @Param("lastReadMessageId") Long lastReadMessageId,
             @Param("userId") Long userId
     );
+
+    @Query("SELECT m FROM Message m " +
+            "WHERE m.chatRoomId = :chatRoomId " +
+            "ORDER BY m.id DESC LIMIT :size")
+    List<Message> findLatestMessages(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("size") int size);
+
+    @Query("SELECT m FROM Message m " +
+            "WHERE m.chatRoomId = :chatRoomId " +
+            "AND m.id < :cursorId " +
+            "ORDER BY m.id DESC LIMIT :size")
+    List<Message> findMessagesBeforeCursor(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("cursorId") Long cursorId,
+            @Param("size") int size);
 }

--- a/src/main/java/com/example/easybooking/chat/service/ChatService.java
+++ b/src/main/java/com/example/easybooking/chat/service/ChatService.java
@@ -4,7 +4,7 @@ import com.example.easybooking.chat.ChatRoomReader;
 import com.example.easybooking.chat.MessageWriter;
 import com.example.easybooking.chat.domain.ChatRoom;
 import com.example.easybooking.chat.dto.request.ChatMessageRequest;
-import com.example.easybooking.chat.dto.response.ChatMessageResponse;
+import com.example.easybooking.chat.dto.response.MessageResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -20,7 +20,7 @@ public class ChatService {
     private final MessageWriter messageWriter;
     private final ChatRoomReader chatRoomReader;
 
-    public ChatMessageResponse saveMessage(Long chatRoomId, Long userId, ChatMessageRequest request) {
+    public MessageResponse saveMessage(Long chatRoomId, Long userId, ChatMessageRequest request) {
         ChatRoom chatRoom = chatRoomReader.read(chatRoomId);
 
         if (!chatRoom.isParticipant(userId)) {

--- a/src/main/java/com/example/easybooking/chat/service/MessageService.java
+++ b/src/main/java/com/example/easybooking/chat/service/MessageService.java
@@ -1,0 +1,32 @@
+package com.example.easybooking.chat.service;
+
+import com.example.easybooking.chat.ChatRoomReader;
+import com.example.easybooking.chat.MessageReader;
+import com.example.easybooking.chat.domain.ChatRoom;
+import com.example.easybooking.chat.dto.response.MessageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+    private final MessageReader messageReader;
+    private final ChatRoomReader chatRoomReader;
+
+    public List<MessageResponse> getMessageHistory(
+            Long chatRoomId,
+            Long userId,
+            Long cursor,
+            int size) {
+
+        ChatRoom chatRoom = chatRoomReader.read(chatRoomId);
+        if (!chatRoom.isParticipant(userId)) {
+            throw new IllegalArgumentException("해당 채팅방에 참여 권한이 없습니다.");
+        }
+
+        return messageReader.readMessages(chatRoomId, cursor, size);
+    }
+
+}

--- a/src/main/java/com/example/easybooking/chat/service/MessageService.java
+++ b/src/main/java/com/example/easybooking/chat/service/MessageService.java
@@ -3,30 +3,44 @@ package com.example.easybooking.chat.service;
 import com.example.easybooking.chat.ChatRoomReader;
 import com.example.easybooking.chat.MessageReader;
 import com.example.easybooking.chat.domain.ChatRoom;
+import com.example.easybooking.chat.domain.Message;
 import com.example.easybooking.chat.dto.response.MessageResponse;
+import com.example.easybooking.user.UserReader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class MessageService {
     private final MessageReader messageReader;
     private final ChatRoomReader chatRoomReader;
+    private final UserReader userReader;
 
     public List<MessageResponse> getMessageHistory(
             Long chatRoomId,
             Long userId,
             Long cursor,
             int size) {
-
         ChatRoom chatRoom = chatRoomReader.read(chatRoomId);
         if (!chatRoom.isParticipant(userId)) {
             throw new IllegalArgumentException("해당 채팅방에 참여 권한이 없습니다.");
         }
 
-        return messageReader.readMessages(chatRoomId, cursor, size);
+        String ownerName = userReader.read(chatRoom.getOwnerId()).getName();
+        String customerName = userReader.read(chatRoom.getCustomerId()).getName();
+
+        Map<Long, String> nameMap = new HashMap<>();
+        nameMap.put(chatRoom.getOwnerId(), ownerName);
+        nameMap.put(chatRoom.getCustomerId(), customerName);
+
+        List<Message> messages = messageReader.readMessages(chatRoomId, cursor, size);
+
+        return messages.stream()
+                .map(m -> MessageResponse.from(m, nameMap.getOrDefault(m.getSenderId(), "알 수 없음")))
+                .toList();
     }
 
 }

--- a/src/main/java/com/example/easybooking/chat/service/MessageService.java
+++ b/src/main/java/com/example/easybooking/chat/service/MessageService.java
@@ -36,7 +36,7 @@ public class MessageService {
         nameMap.put(chatRoom.getOwnerId(), ownerName);
         nameMap.put(chatRoom.getCustomerId(), customerName);
 
-        List<Message> messages = messageReader.readMessages(chatRoomId, cursor, size);
+        List<Message> messages = messageReader.readMessages(chatRoom, cursor, size, userId);
 
         return messages.stream()
                 .map(m -> MessageResponse.from(m, nameMap.getOrDefault(m.getSenderId(), "알 수 없음")))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,5 +58,5 @@ spring:
       redirect: http://localhost:5173/auth
 jwt:
   secret: ${JWT_SECRET_KEY}
-  access-token-expiration: 3600000
-  refresh-token-expiration: 604800000
+  access-token-expiration: 31536000000  # 로컬 테스트용, 유효기간 1년
+  refresh-token-expiration: 3153600000


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

#38 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

### senderName 처리

메시지 조회 시, `senderName`을 결정해야하는게 까다로웠다. 

`senderId`는 `messgae `엔티티에 저장돼있지만 송신자의 이름을 같이 넣어주려면 따로 처리가 필요하다.

`chatRoom`에 저장된 사용자의 id를 통해 고객과 점주를 불러오고 

메시지를 조회한 뒤 하나씩 순회하면서 고객의 이름이나 점주의 이름을 넣어주어야했다.

`Message` 엔티티를 비정규화 시키는게 더 편할 것 같아서 고민도 했다.

하지만 `Message`에 송신자의 이름을 넣어놓으면, 만약 송신자가 이름을 변경했을 시, 이름 변경 전 채팅 메시지에는 송신자의 변경 전 이름이 뜨기 때문에 동기화가 오히려 더 번거로울 것 같았다. 

### 안 읽은 메시지 수 처리

또한 사용자가 채팅방 목록을 확인할 때, 안 읽은 메시지의 수를 계산해야 하므로, 채팅방에 `lastReadMessageId`를 추가하였다.

사용자가 채팅방에 접근하여 메시지 히스토리 조회 시, 채팅방의 `lastReadMessageId`를 업데이트하도록 만들었다.






## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
