### PR TITLE
feat : 메시지 읽음 처리 api 구현

### DIFF
--- a/src/main/java/com/example/easybooking/chat/ChatRoomWriter.java
+++ b/src/main/java/com/example/easybooking/chat/ChatRoomWriter.java
@@ -2,10 +2,11 @@ package com.example.easybooking.chat;
 
 import com.example.easybooking.chat.domain.ChatRoom;
 import com.example.easybooking.chat.repository.ChatRoomRepository;
-import com.example.easybooking.shop.domain.Shop;
 import com.example.easybooking.shop.ShopReader;
+import com.example.easybooking.shop.domain.Shop;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -18,5 +19,19 @@ public class ChatRoomWriter {
         Long ownerId = shop.getOwnerId();
         ChatRoom chatRoom = ChatRoom.create(shopId, ownerId, userId);
         return chatRoomRepository.save(chatRoom);
+    }
+
+    @Transactional
+    public void updateLastReadMessage(Long chatRoomId, Long userId, Long lastReadMessageId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 채팅방입니다."));
+
+        // 참여자 검증
+        if (!chatRoom.isParticipant(userId)) {
+            throw new IllegalArgumentException("채팅방 참여자가 아닙니다.");
+        }
+
+        chatRoom.updateLastReadMessageId(lastReadMessageId, userId);
+        chatRoomRepository.save(chatRoom);
     }
 }

--- a/src/main/java/com/example/easybooking/chat/dto/request/UpdateLastReadMessageRequest.java
+++ b/src/main/java/com/example/easybooking/chat/dto/request/UpdateLastReadMessageRequest.java
@@ -1,0 +1,8 @@
+package com.example.easybooking.chat.dto.request;
+
+import lombok.Data;
+
+@Data
+public class UpdateLastReadMessageRequest {
+    Long lastReadMessageId;
+}

--- a/src/main/java/com/example/easybooking/chat/presentation/ChatRoomController.java
+++ b/src/main/java/com/example/easybooking/chat/presentation/ChatRoomController.java
@@ -2,18 +2,20 @@ package com.example.easybooking.chat.presentation;
 
 import com.example.easybooking.auth.AuthenticatedUser;
 import com.example.easybooking.auth.RequireAuthenticatedUser;
+import com.example.easybooking.chat.dto.request.UpdateLastReadMessageRequest;
 import com.example.easybooking.chat.dto.response.ChatRoomListResponse;
 import com.example.easybooking.chat.dto.response.ChatRoomResponse;
 import com.example.easybooking.chat.service.ChatRoomService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/chat/rooms")
@@ -23,28 +25,40 @@ public class ChatRoomController {
     private final ChatRoomService chatRoomService;
 
     /**
-     * 특정 샵의 채팅방 조회 또는 생성
-     * 정식 인증 토큰이 필요합니다.
+     * 특정 샵의 채팅방 조회 또는 생성 정식 인증 토큰이 필요합니다.
      */
     @GetMapping("shop/{shopId}")
     public ResponseEntity<ChatRoomResponse> getChatRoom(
             @PathVariable Long shopId,
             @RequireAuthenticatedUser AuthenticatedUser user) {
         return ResponseEntity.ok(
-            chatRoomService.getChatRoom(shopId, user.getUserId())
+                chatRoomService.getChatRoom(shopId, user.getUserId())
         );
     }
 
     /**
-     * 내 채팅방 목록 조회
-     * 정식 인증 토큰이 필요합니다.
+     * 내 채팅방 목록 조회 정식 인증 토큰이 필요합니다.
      */
     @GetMapping("/")
     public ResponseEntity<List<ChatRoomListResponse>> getChatRoomList(
             @RequireAuthenticatedUser AuthenticatedUser user
     ) {
         return ResponseEntity.ok(
-            chatRoomService.getChatRoomList(user.getUserId())
+                chatRoomService.getChatRoomList(user.getUserId())
         );
+    }
+
+    // ChatRoomController.java
+    @PatchMapping("/{chatRoomId}/last-read-message")
+    public ResponseEntity<Void> updateLastReadMessage(
+            @PathVariable Long chatRoomId,
+            @RequestBody UpdateLastReadMessageRequest request,
+            @RequireAuthenticatedUser AuthenticatedUser user) {
+        chatRoomService.updateLastReadMessage(
+                chatRoomId,
+                user.getUserId(),
+                request.getLastReadMessageId()
+        );
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/easybooking/chat/service/ChatRoomService.java
+++ b/src/main/java/com/example/easybooking/chat/service/ChatRoomService.java
@@ -1,15 +1,14 @@
 package com.example.easybooking.chat.service;
 
+import com.example.easybooking.chat.ChatRoomReader;
 import com.example.easybooking.chat.ChatRoomWriter;
 import com.example.easybooking.chat.domain.ChatRoom;
 import com.example.easybooking.chat.dto.response.ChatRoomListResponse;
 import com.example.easybooking.chat.dto.response.ChatRoomResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import com.example.easybooking.chat.ChatRoomReader;
-
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -35,4 +34,10 @@ public class ChatRoomService {
     public List<ChatRoomListResponse> getChatRoomList(Long userId) {
         return chatRoomReader.getChatRoomList(userId);
     }
+
+    public void updateLastReadMessage(Long chatRoomId, Long userId, Long lastReadMessageId) {
+        chatRoomWriter.updateLastReadMessage(chatRoomId, userId, lastReadMessageId);
+    }
+
+
 }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

#41 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

## 채팅방 목록내 안 읽은 메시지 수 표시

안 읽은 메시지 수 계산은 chatRoom의 `lastReadMessageId`보다 id가 큰 메시지를 count하여 이루어진다

하지만 `lastReadMessageId`는 **메시지 히스토리 조회 시**에 업데이트 되므로, 실시간 채팅을 주고받다가 채팅방에서 나왔을 때 (퇴장x) , 주고받은 메시지가 채팅방 목록에서 안 읽은 메시지 수로 표현된다.

따라서, 채팅방에서 나갈 때, 채팅방의 전체 메시지를 읽음 처리할 필요가 있기 때문에 해당 api를 구현하였다. 


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
