### PR TITLE
refactor : 로그인/회원가입 시, 응답 DTO에 userId 추가

### DIFF
--- a/src/main/java/com/example/easybooking/auth/dto/AuthResponse.java
+++ b/src/main/java/com/example/easybooking/auth/dto/AuthResponse.java
@@ -9,21 +9,25 @@ import lombok.Getter;
 public class AuthResponse {
     private String accessToken;
     private String refreshToken;
+    private Long userId;
     private String role;
     private String message;
     private AuthStatus authStatus;
     private UserType userType;
 
-    public static AuthResponse loginSuccess(String accessToken, String refreshToken, String role, UserType userType) {
+    public static AuthResponse loginSuccess(String accessToken, String refreshToken, Long userId, String role,
+                                            UserType userType) {
         return AuthResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .userId(userId)
                 .role(role)
                 .authStatus(AuthStatus.LOGIN_SUCCESS)
                 .message("로그인 성공")
                 .userType(userType)
                 .build();
     }
+
     public static AuthResponse signupRequired(String tempToken) {
         return AuthResponse.builder()
                 .accessToken(tempToken)
@@ -31,10 +35,11 @@ public class AuthResponse {
                 .message("회원가입 필요")
                 .build();
     }
+
     public static AuthResponse failure(String message) {
-            return AuthResponse.builder()
-                    .message(message)
-                    .build();
+        return AuthResponse.builder()
+                .message(message)
+                .build();
     }
 
     public enum AuthStatus {

--- a/src/main/java/com/example/easybooking/auth/service/AuthService.java
+++ b/src/main/java/com/example/easybooking/auth/service/AuthService.java
@@ -1,20 +1,15 @@
 package com.example.easybooking.auth.service;
 
-import java.util.Optional;
-
-import com.example.easybooking.auth.dto.AuthResponse;
 import com.example.easybooking.auth.JwtUtil;
-import com.example.easybooking.auth.dto.KakaoDto;
 import com.example.easybooking.auth.KakaoUtil;
-import com.example.easybooking.user.domain.UserType;
-import org.springframework.stereotype.Service;
-
-import com.example.easybooking.user.domain.User;
+import com.example.easybooking.auth.dto.AuthResponse;
+import com.example.easybooking.auth.dto.KakaoDto;
 import com.example.easybooking.user.UserReader;
-import com.example.easybooking.user.UserWriter;
-
+import com.example.easybooking.user.domain.User;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
@@ -25,22 +20,21 @@ public class AuthService {
     private final JwtUtil jwtUtil;
 
     public AuthResponse oAuthLogin(String accessCode) {
-        try{
+        try {
             KakaoDto.KakaoId kakaoId = kakaoUtil.requestKakaoId(accessCode);
             Optional<User> existingUser = userReader.getUserByProviderId(String.valueOf(kakaoId.getId()));
 
-            if(existingUser.isPresent()){
+            if (existingUser.isPresent()) {
                 User user = existingUser.get();
                 String accessToken = jwtUtil.generateAccessToken(user.getId(), user.getRole().name());
                 String refreshToken = jwtUtil.generateRefreshToken(user.getId());
-                return AuthResponse.loginSuccess(accessToken, refreshToken, user.getRole().name(), user.getUserType());
-            }
-            else{
+                return AuthResponse.loginSuccess(accessToken, refreshToken, user.getId(), user.getRole().name(),
+                        user.getUserType());
+            } else {
                 String tempToken = jwtUtil.generateTempToken(String.valueOf(kakaoId.getId()));
                 return AuthResponse.signupRequired(tempToken);
             }
-        }
-        catch (Exception e){
+        } catch (Exception e) {
             log.error("OAuth login failed", e);
             return AuthResponse.failure("OAuth 로그인 실패: " + e.getMessage());
         }

--- a/src/main/java/com/example/easybooking/user/dto/CustomerSignUpResponse.java
+++ b/src/main/java/com/example/easybooking/user/dto/CustomerSignUpResponse.java
@@ -14,13 +14,15 @@ import lombok.NoArgsConstructor;
 @Builder
 public class CustomerSignUpResponse {
     private UserType userType;
+    private Long userId;
     private String name;
     private String phoneNumber;
     private AuthTokens tokens;
 
-    public static CustomerSignUpResponse of(UserType userType,User user, AuthTokens tokens) {
+    public static CustomerSignUpResponse of(UserType userType, User user, AuthTokens tokens) {
         return CustomerSignUpResponse.builder()
                 .userType(userType)
+                .userId(user.getId())
                 .name(user.getName())
                 .phoneNumber(user.getPhoneNumber())
                 .tokens(tokens)

--- a/src/main/java/com/example/easybooking/user/dto/OwnerSignUpResponse.java
+++ b/src/main/java/com/example/easybooking/user/dto/OwnerSignUpResponse.java
@@ -14,13 +14,15 @@ import lombok.NoArgsConstructor;
 @Builder
 public class OwnerSignUpResponse {
     private UserType userType;
+    private Long userId;
     private String name;
     private String phoneNumber;
     private AuthTokens tokens;
 
-    public static OwnerSignUpResponse of(UserType userType,User user, AuthTokens tokens) {
+    public static OwnerSignUpResponse of(UserType userType, User user, AuthTokens tokens) {
         return OwnerSignUpResponse.builder()
                 .userType(userType)
+                .userId(user.getId())
                 .name(user.getName())
                 .phoneNumber(user.getPhoneNumber())
                 .tokens(tokens)

--- a/src/main/java/com/example/easybooking/user/service/UserService.java
+++ b/src/main/java/com/example/easybooking/user/service/UserService.java
@@ -5,9 +5,11 @@ import com.example.easybooking.auth.AuthTokens;
 import com.example.easybooking.auth.JwtUtil;
 import com.example.easybooking.user.UserWriter;
 import com.example.easybooking.user.domain.User;
-import com.example.easybooking.user.domain.repository.UserRepository;
 import com.example.easybooking.user.domain.UserType;
-import com.example.easybooking.user.dto.*;
+import com.example.easybooking.user.dto.CustomerSignUpRequest;
+import com.example.easybooking.user.dto.CustomerSignUpResponse;
+import com.example.easybooking.user.dto.OwnerSignUpRequest;
+import com.example.easybooking.user.dto.OwnerSignUpResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,20 +19,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
     private final UserWriter userWriter;
     private final JwtUtil jwtUtil;
-    private final UserRepository userRepository;
 
     public CustomerSignUpResponse signUpCustomer(String providerId, CustomerSignUpRequest request) {
         User savedUser = userWriter.registerCustomer(request, providerId);
         AuthTokens tokens = jwtUtil.generateTokens(savedUser.getId(), savedUser.getRole().name());
 
-        return CustomerSignUpResponse.of(UserType.CUSTOMER,savedUser, tokens);
+        return CustomerSignUpResponse.of(UserType.CUSTOMER, savedUser, tokens);
     }
 
     public OwnerSignUpResponse signUpOwner(String providerId, OwnerSignUpRequest request) {
         User savedUser = userWriter.registerOwner(request, providerId);
         AuthTokens tokens = jwtUtil.generateTokens(savedUser.getId(), savedUser.getRole().name());
-        return OwnerSignUpResponse.of(UserType.OWNER,savedUser,tokens);
+        return OwnerSignUpResponse.of(UserType.OWNER, savedUser, tokens);
     }
+
     @Transactional
     public void deleteUser(Long userId) {
         userWriter.deleteUser(userId);


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

#47 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

기존 채팅방 메시지 히스토리를 조회했을 때, senderId로 메시지간 구분은 가능했지만, 어떤게 자신의 것인지는 프론트에서 구분하지 못했다.

따라서 로그인/회원가입 시, userId를 응답에 추가하여 프론트에서 사용자 본인의 id를 가질 수 있게 만들었다.


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
