### PR TITLE
feat : 예약 확정&거절 api 및 예약 폼 조회 api 구현

### DIFF
--- a/src/main/java/com/example/easybooking/form/FormInitializer.java
+++ b/src/main/java/com/example/easybooking/form/FormInitializer.java
@@ -50,7 +50,7 @@ public class FormInitializer {
                 // 1. 이름
                 createDto("name", "이름", FieldType.TEXT, true, 1, "예약자 이름", null),
                 // 2. 전화번호
-                createDto("phone", "전화번호", FieldType.NUMBER, true, 2, "010xxxxxxxx", null),
+                createDto("phone", "전화번호", FieldType.TEXT, true, 2, "010xxxxxxxx", null),
                 // 3. 날짜
                 createDto("date", "날짜", FieldType.TEXT, true, 3, "2025-10-26", null),
                 // 4. 제거 유무

--- a/src/main/java/com/example/easybooking/form/FormInitializer.java
+++ b/src/main/java/com/example/easybooking/form/FormInitializer.java
@@ -1,0 +1,81 @@
+package com.example.easybooking.form;
+
+import com.example.easybooking.form.domain.Form;
+import com.example.easybooking.form.domain.FormField;
+import com.example.easybooking.form.domain.repository.FormRepository;
+import com.example.easybooking.form.domain.repository.FormFieldRepository;
+import com.example.easybooking.form.domain.type.FieldType;
+import com.example.easybooking.form.dto.FormFieldPatchDto;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 서버 기동 시 기본 폼 템플릿을 DB에 생성
+ */
+
+@Component
+@RequiredArgsConstructor
+public class FormInitializer {
+
+    private final FormRepository formRepository;
+    private final FormFieldRepository formFieldRepository;
+
+    @PostConstruct
+    public void initializeDefaultForm() {
+        if (formRepository.findById(1L).isPresent()) {
+            return;
+        }
+
+
+        // 기본 폼 (Form Id = 1) 생성
+        Form defaultFormTemplate = Form.createFormTemplate();
+        Form savedForm = formRepository.save(defaultFormTemplate);
+
+        // 기본 폼 목록 생성 및 저장
+        List<FormFieldPatchDto> defaultFieldsDtos = buildDefaultFieldsDtos();
+        List<FormField> newFields = defaultFieldsDtos.stream()
+                .map(dto -> FormField.createFrom(dto, savedForm))
+                .collect(Collectors.toList());
+
+        formFieldRepository.saveAll(newFields);
+    }
+
+
+    private List<FormFieldPatchDto> buildDefaultFieldsDtos() {
+        return List.of(
+                // 1. 이름
+                createDto("name", "이름", FieldType.TEXT, true, 1, "예약자 이름", null),
+                // 2. 전화번호
+                createDto("phone", "전화번호", FieldType.NUMBER, true, 2, "010xxxxxxxx", null),
+                // 3. 날짜
+                createDto("date", "날짜", FieldType.TEXT, true, 3, "2025-10-26", null),
+                // 4. 제거 유무
+                createDto("removal", "제거 유무", FieldType.RADIO, true, 4, null, List.of("예", "아니오")),
+                // 5. 손/발
+                createDto("part", "손/발", FieldType.RADIO, true, 5, null, List.of("손", "발")),
+                // 6. 연장/래핑
+                createDto("wrapping", "연장/래핑", FieldType.NUMBER, false, 6, "추가 길이 (mm)", null),
+                // 7. 디자인 사진
+                createDto("photo", "디자인 사진", FieldType.FILE, false, 7, "사진 첨부", null),
+                // 8. 요구사항 텍스트
+                createDto("requests", "요구사항", FieldType.TEXTAREA, false, 8, "자유롭게 입력해주세요", null)
+        );
+    }
+
+    private FormFieldPatchDto createDto(String fieldId, String label, FieldType type, Boolean required, Integer order, String placeholder, List<String> options) {
+        return FormFieldPatchDto.builder()
+                .fieldId(fieldId)
+                .label(label)
+                .type(type)
+                .required(required)
+                .displayOrder(order)
+                .placeholder(placeholder)
+                .options(options)
+                .operation(FormFieldPatchDto.PatchOperation.ADD)
+                .build();
+    }
+}

--- a/src/main/java/com/example/easybooking/form/FormService.java
+++ b/src/main/java/com/example/easybooking/form/FormService.java
@@ -7,6 +7,7 @@ import com.example.easybooking.form.dto.request.FormPatchRequest;
 import com.example.easybooking.form.mapper.FormMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class FormService {
         return formMapper.toDto(form);
     }
 
+    @Transactional
     public void createDefaultForm(Long shopId) {
         formCopyUtil.copyDefaultFormToShop(shopId);
     }

--- a/src/main/java/com/example/easybooking/form/FormService.java
+++ b/src/main/java/com/example/easybooking/form/FormService.java
@@ -5,9 +5,16 @@ import com.example.easybooking.form.domain.FormCopyUtil;
 import com.example.easybooking.form.dto.FormResponse;
 import com.example.easybooking.form.dto.request.FormPatchRequest;
 import com.example.easybooking.form.mapper.FormMapper;
+import com.example.easybooking.shop.ShopReader;
+import com.example.easybooking.shop.domain.Shop;
+import com.example.easybooking.user.UserReader;
+import com.example.easybooking.user.domain.User;
+import com.example.easybooking.user.domain.UserType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import org.springframework.security.access.AccessDeniedException;
 
 @Service
 @RequiredArgsConstructor
@@ -17,8 +24,23 @@ public class FormService {
     private final FormMapper formMapper;
     private final FormCopyUtil formCopyUtil;
     private final FormPatcher formPatcher;
+    private final ShopReader shopReader;
+    private final UserReader userReader;
 
-    public FormResponse getForm(Long shopId){
+    public FormResponse getForm(Long shopId, Long userId){
+        // 사용자 정보 및 UserType 조회
+        User user = userReader.read(userId);
+        UserType userType = user.getUserType();
+
+        // 점주(OWNER) 요청시 소유권 검증
+        if (userType == UserType.OWNER) {
+            Shop shop = shopReader.read(shopId);
+
+            if (!shop.getOwnerId().equals(userId)) {
+                throw new AccessDeniedException("점주는 본인이 소유한 매장의 폼만 조회할 수 있습니다.");
+            }
+        }
+
         Form form = formReader.readByShopId(shopId);
         return formMapper.toDto(form);
     }

--- a/src/main/java/com/example/easybooking/form/domain/Form.java
+++ b/src/main/java/com/example/easybooking/form/domain/Form.java
@@ -21,7 +21,7 @@ public class Form {
 
     public static Form createForm(Form defaultForm, Long shopId) {
         Form form = new Form();
-        form.shopId = defaultForm.getShopId();
+        form.shopId = shopId;
         form.name = defaultForm.getName();
         form.title = defaultForm.getTitle();
         return form;
@@ -29,7 +29,7 @@ public class Form {
 
     public static Form createFormTemplate() {
         Form form = new Form();
-        form.shopId = 0L;
+        // form.shopId = 0L;
         form.name = "시스템 기본 폼";
         form.title = "기본 설정 템플릿";
 

--- a/src/main/java/com/example/easybooking/form/domain/Form.java
+++ b/src/main/java/com/example/easybooking/form/domain/Form.java
@@ -27,6 +27,15 @@ public class Form {
         return form;
     }
 
+    public static Form createFormTemplate() {
+        Form form = new Form();
+        form.shopId = 0L;
+        form.name = "시스템 기본 폼";
+        form.title = "기본 설정 템플릿";
+
+        return form;
+    }
+
     public void updateName(String name) {
         this.name = name;
     }

--- a/src/main/java/com/example/easybooking/form/mapper/FormFieldMapper.java
+++ b/src/main/java/com/example/easybooking/form/mapper/FormFieldMapper.java
@@ -20,6 +20,11 @@ public class FormFieldMapper {
                 .label(formField.getLabel())
                 .type(formField.getType())
                 .required(formField.getRequired())
+                .placeholder(formField.getPlaceholder())
+                .min(formField.getMinValue())
+                .max(formField.getMaxValue())
+                .accept(formField.getAcceptTypes())
+                .options(formField.getOptions())
                 .build();
     }
     public List<FormFieldDto> getFormFieldDto(Form form){

--- a/src/main/java/com/example/easybooking/form/presentation/FormController.java
+++ b/src/main/java/com/example/easybooking/form/presentation/FormController.java
@@ -1,5 +1,7 @@
 package com.example.easybooking.form.presentation;
 
+import com.example.easybooking.auth.AuthenticatedUser;
+import com.example.easybooking.auth.RequireAuthenticatedUser;
 import com.example.easybooking.form.dto.request.FormPatchRequest;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -20,8 +22,12 @@ public class FormController {
     private final FormService formService;
 
     @GetMapping("/{shopId}")
-    public FormResponse getForm(@PathVariable Long shopId){
-        FormResponse formResponse = formService.getForm(shopId);
+    public FormResponse getForm(
+            @PathVariable Long shopId,
+            @RequireAuthenticatedUser AuthenticatedUser authenticatedUser) {
+
+        Long userId = authenticatedUser.getUserId();
+        FormResponse formResponse = formService.getForm(shopId, userId);
         return formResponse;
     }
 

--- a/src/main/java/com/example/easybooking/reservation/domain/Reservation.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/Reservation.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "reservations")
@@ -34,7 +36,11 @@ public class Reservation {
     @Column(nullable = false)
     private LocalTime time;
 
-    private String designImageURL;
+    //private String designImageURL;
+    @ElementCollection
+    @CollectionTable(name = "reservation_photos", joinColumns = @JoinColumn(name = "reservation_id"))
+    @Column(name = "photo_url")
+    private List<String> designImageURLs = new ArrayList<>();
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -64,7 +70,7 @@ public class Reservation {
             LocalDate date,
             LocalTime time,
             String formDataJson,
-            String designImageURL) {
+            List<String> designImageURLs) {
 
         Reservation reservation = new Reservation();
 
@@ -74,7 +80,7 @@ public class Reservation {
         reservation.date = date;
         reservation.time = time;
         reservation.formDataJson = formDataJson;
-        reservation.designImageURL = designImageURL;
+        reservation.designImageURLs = designImageURLs;
         reservation.status = Status.PENDING;  // 초기 상태 : 대기
         reservation.createdAt = LocalDateTime.now();
 

--- a/src/main/java/com/example/easybooking/reservation/domain/Reservation.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/Reservation.java
@@ -41,6 +41,10 @@ public class Reservation {
 
     private String rejectionReason;
 
+    @Lob
+    @Column(nullable = false)
+    private String formDataJson;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Status status;     // 예약 상태
@@ -58,6 +62,7 @@ public class Reservation {
             Long customerId,
             LocalDate date,
             LocalTime time,
+            String formDataJson,
             String designImageURL) {
 
         Reservation reservation = new Reservation();
@@ -67,6 +72,7 @@ public class Reservation {
         reservation.customerId = customerId;
         reservation.date = date;
         reservation.time = time;
+        reservation.formDataJson = formDataJson;
         reservation.designImageURL = designImageURL;
         reservation.status = Status.PENDING;  // 초기 상태 : 대기
         reservation.createdAt = LocalDateTime.now();

--- a/src/main/java/com/example/easybooking/reservation/domain/Reservation.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/Reservation.java
@@ -40,6 +40,7 @@ public class Reservation {
     private LocalDateTime createdAt;
 
     private String rejectionReason;
+    private String confirmationMessage;
 
     @Lob
     @Column(nullable = false)
@@ -80,10 +81,11 @@ public class Reservation {
         return reservation;
     }
 
-    public void confirm() {
+    public void confirm(String message) {
         if (this.status != Status.PENDING) {
             throw new IllegalStateException("대기 상태의 예약만 확정할 수 있습니다.");
         }
+        this.confirmationMessage = message;
         this.status = Status.CONFIRMED;
     }
 

--- a/src/main/java/com/example/easybooking/reservation/domain/Reservation.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/Reservation.java
@@ -39,6 +39,8 @@ public class Reservation {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    private String rejectionReason;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Status status;     // 예약 상태
@@ -79,10 +81,11 @@ public class Reservation {
         this.status = Status.CONFIRMED;
     }
 
-    public void reject() {
+    public void reject(String reason) {
         if (this.status != Status.PENDING) {
             throw new IllegalStateException("대기 상태의 예약만 거절할 수 있습니다.");
         }
+        this.rejectionReason = reason;
         this.status = Status.REJECTED;
     }
 

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationConfirmRequest.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationConfirmRequest.java
@@ -1,0 +1,12 @@
+package com.example.easybooking.reservation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ReservationConfirmRequest {
+    // 수락 시 전달사항 필수로 받음
+    @NotBlank(message = "수락 시 고객에게 전달할 메시지는 필수 입력 사항입니다.")
+    private String message;
+
+}

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationCreateRequest.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationCreateRequest.java
@@ -3,6 +3,7 @@ package com.example.easybooking.reservation.dto;
 import lombok.Data;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Map;
 
 // 고객이 입력하는 모든 예약 정보를 담음
 // 날짜, 시간, 샵 ID, 사진 URL 등
@@ -10,12 +11,15 @@ import java.time.LocalTime;
 @Data
 public class ReservationCreateRequest {
     private Long shopId;
-    private LocalDate date;
-    private LocalTime time;
-    private String designImageURL;
+    // private LocalDate date;
+    // private LocalTime time;
+    // private String designImageURL;
 
     // 추가로 필요한 정보 ?
     // 메모, 고객 전화번호 등
-    private String name;         // 고객 이름
-    private String phoneNumber;  // 고객 전화번호
+    // private String name;         // 고객 이름
+    // private String phoneNumber;  // 고객 전화번호
+
+    // 폼 데이터 필드 추가
+    private Map<String, String> formData;
 }

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationRejectRequest.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationRejectRequest.java
@@ -1,0 +1,11 @@
+package com.example.easybooking.reservation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class ReservationRejectRequest {
+    // 거절 사유 필수로 받음
+    @NotBlank(message = "거절 사유는 필수 입력 사항입니다.")
+    private String reason;
+}

--- a/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
+++ b/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
@@ -3,8 +3,10 @@ package com.example.easybooking.reservation.presentation;
 import com.example.easybooking.auth.AuthenticatedUser;
 import com.example.easybooking.auth.RequireAuthenticatedUser;
 import com.example.easybooking.reservation.dto.ReservationCreateRequest;
+import com.example.easybooking.reservation.dto.ReservationRejectRequest;
 import com.example.easybooking.reservation.dto.ReservationResponse;
 import com.example.easybooking.reservation.service.ReservationService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
@@ -60,11 +62,12 @@ public class ReservationController {
     @PutMapping("/{id}/reject")
     public ResponseEntity<Void> rejectReservation(
             @PathVariable("id") Long reservationId,
-            @RequireAuthenticatedUser AuthenticatedUser authenticatedUser) {
+            @RequireAuthenticatedUser AuthenticatedUser authenticatedUser,
+            @Valid @RequestBody ReservationRejectRequest request) {
 
         Long ownerUserId = authenticatedUser.getUserId();
 
-        reservationService.rejectReservation(reservationId, ownerUserId);
+        reservationService.rejectReservation(reservationId, ownerUserId, request);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
+++ b/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
@@ -6,6 +6,7 @@ import com.example.easybooking.reservation.dto.ReservationCreateRequest;
 import com.example.easybooking.reservation.dto.ReservationResponse;
 import com.example.easybooking.reservation.service.ReservationService;
 import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -53,8 +54,20 @@ public class ReservationController {
         return ResponseEntity.noContent().build();
     }
 
+    /**
+     * 원장님(OWNER) 예약 거절 API
+     */
+    @PutMapping("/{id}/reject")
+    public ResponseEntity<Void> rejectReservation(
+            @PathVariable("id") Long reservationId,
+            @RequireAuthenticatedUser AuthenticatedUser authenticatedUser) {
 
+        Long ownerUserId = authenticatedUser.getUserId();
 
+        reservationService.rejectReservation(reservationId, ownerUserId);
+
+        return ResponseEntity.noContent().build();
+    }
 
     // TODO: [GET] 고객 예약 내역 조회 API
     // TODO: [PUT] 예약 취소/거절 API

--- a/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
+++ b/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
@@ -8,10 +8,7 @@ import com.example.easybooking.reservation.service.ReservationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import org.slf4j.Logger;
@@ -41,7 +38,24 @@ public class ReservationController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    /**
+     * 원장님(OWNER) 예약 확정 API
+     */
+    @PutMapping("/{id}/confirm")
+    public ResponseEntity<Void> confirmReservation(
+            @PathVariable("id") Long reservationId,
+            @RequireAuthenticatedUser AuthenticatedUser authenticatedUser) {
+
+        Long ownerUserId = authenticatedUser.getUserId();
+
+        reservationService.confirmReservation(reservationId, ownerUserId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+
+
+
     // TODO: [GET] 고객 예약 내역 조회 API
-    // TODO: [PUT] 원장님 예약 확정 API
     // TODO: [PUT] 예약 취소/거절 API
 }

--- a/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
+++ b/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
@@ -2,6 +2,7 @@ package com.example.easybooking.reservation.presentation;
 
 import com.example.easybooking.auth.AuthenticatedUser;
 import com.example.easybooking.auth.RequireAuthenticatedUser;
+import com.example.easybooking.reservation.dto.ReservationConfirmRequest;
 import com.example.easybooking.reservation.dto.ReservationCreateRequest;
 import com.example.easybooking.reservation.dto.ReservationRejectRequest;
 import com.example.easybooking.reservation.dto.ReservationResponse;
@@ -47,11 +48,12 @@ public class ReservationController {
     @PutMapping("/{id}/confirm")
     public ResponseEntity<Void> confirmReservation(
             @PathVariable("id") Long reservationId,
-            @RequireAuthenticatedUser AuthenticatedUser authenticatedUser) {
+            @RequireAuthenticatedUser AuthenticatedUser authenticatedUser,
+            @Valid @RequestBody ReservationConfirmRequest request) {
 
         Long ownerUserId = authenticatedUser.getUserId();
 
-        reservationService.confirmReservation(reservationId, ownerUserId);
+        reservationService.confirmReservation(reservationId, ownerUserId, request);
 
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -3,6 +3,7 @@ package com.example.easybooking.reservation.service;
 import com.example.easybooking.reservation.ReservationReader;
 import com.example.easybooking.reservation.ReservationWriter;
 import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.reservation.dto.ReservationConfirmRequest;
 import com.example.easybooking.reservation.dto.ReservationCreateRequest;
 import com.example.easybooking.reservation.dto.ReservationRejectRequest;
 import com.example.easybooking.reservation.dto.ReservationResponse;
@@ -94,7 +95,7 @@ public class ReservationService {
      * - Reservation 엔티티의 confirm() 메소드 호출
      */
     @Transactional
-    public void confirmReservation(Long reservationId, Long ownerUserId) {
+    public void confirmReservation(Long reservationId, Long ownerUserId, ReservationConfirmRequest request) {
         // 1. 원장님(OWNER) 권한 검증
         User user = userReader.read(ownerUserId);
 
@@ -112,7 +113,7 @@ public class ReservationService {
 
         // 4. 엔티티 상태 변경
         log.info("예약 ID: {} - 상태 변경 전: {}", reservationId, reservation.getStatus());
-        reservation.confirm();
+        reservation.confirm(request.getMessage());
         log.info("예약 ID: {} - 상태 변경 후: {}", reservationId, reservation.getStatus());
     }
 

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -7,10 +7,11 @@ import com.example.easybooking.reservation.dto.ReservationConfirmRequest;
 import com.example.easybooking.reservation.dto.ReservationCreateRequest;
 import com.example.easybooking.reservation.dto.ReservationRejectRequest;
 import com.example.easybooking.reservation.dto.ReservationResponse;
+import com.example.easybooking.shop.ShopReader;
+import com.example.easybooking.shop.domain.Shop;
 import com.example.easybooking.user.UserReader;
 import com.example.easybooking.user.domain.User;
 import com.example.easybooking.user.domain.UserType;
-import com.example.easybooking.user.service.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.nio.file.AccessDeniedException;
+import org.springframework.security.access.AccessDeniedException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.Map;
@@ -33,9 +34,10 @@ public class ReservationService {
     private final ReservationWriter reservationWriter;   // Writer 주입
     private final ReservationReader reservationReader;   // Reader 주입
     private final UserReader userReader;
-    private final UserService userService;
+    private final ShopReader shopReader;
 
     private final ObjectMapper objectMapper;
+
 
     /**
      * 1. 고객 예약 신청 로직 (Create)
@@ -43,10 +45,10 @@ public class ReservationService {
     @Transactional
     public ReservationResponse createReservation(ReservationCreateRequest request, Long userId) {
         Long customerUserId = userId;
-        // 현재는 샵 ID와 담담 원장님 ID를 모두 shopId로 설정함. 추후 확장 예정.
-        // 현재 shopId는 원장님 User.id
         Long shopId = request.getShopId();
-        Long ownerUserId = shopId;
+
+        Shop shop = shopReader.read(shopId);
+        Long ownerUserId = shop.getOwnerId();
 
         Map<String, String> formData = request.getFormData();
         String formDataJson;
@@ -107,8 +109,8 @@ public class ReservationService {
         Reservation reservation = reservationReader.getById(reservationId);
 
         // 3. 샵 일치 검증: 예약된 샵 ID(Reservation.shopId)와 현재 원장님 ID가 일치하는지 확인
-        if (!reservation.getShopId().equals(ownerUserId)) {
-            throw new IllegalStateException("해당 샵의 예약에 대한 처리 권한이 없습니다.");
+        if (!reservation.getOwnerUserId().equals(ownerUserId)) {
+            throw new AccessDeniedException("해당 샵의 예약에 대한 처리 권한이 없습니다.");
         }
 
         // 4. 엔티티 상태 변경
@@ -132,8 +134,8 @@ public class ReservationService {
         Reservation reservation = reservationReader.getById(reservationId);
 
         // 3. 샵 일치 검정
-        if (!reservation.getShopId().equals(ownerUserId)) {
-            throw new IllegalStateException("해당 샵의 예약에 대한 처리 권한이 없습니다.");
+        if (!reservation.getOwnerUserId().equals(ownerUserId)) {
+            throw new AccessDeniedException("해당 샵의 예약에 대한 처리 권한이 없습니다.");
         }
 
         // 4. 엔티티 상태 변경

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -5,19 +5,27 @@ import com.example.easybooking.reservation.ReservationWriter;
 import com.example.easybooking.reservation.domain.Reservation;
 import com.example.easybooking.reservation.dto.ReservationCreateRequest;
 import com.example.easybooking.reservation.dto.ReservationResponse;
+import com.example.easybooking.user.UserReader;
+import com.example.easybooking.user.domain.User;
+import com.example.easybooking.user.domain.UserType;
 import com.example.easybooking.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.nio.file.AccessDeniedException;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReservationService {
+    private static final Logger log = LoggerFactory.getLogger(ReservationService.class);
 
 
     private final ReservationWriter reservationWriter;   // Writer 주입
     private final ReservationReader reservationReader;   // Reader 주입
+    private final UserReader userReader;
 
     private final UserService userService;
 
@@ -46,10 +54,35 @@ public class ReservationService {
         return new ReservationResponse(savedReservation);
     }
 
+    /**
+     * 2. 원장님 예약 수락(확정) 로직 (Update)
+     * - OWNER 권한 검증
+     * - 샵 일치 검증 (본인 샵 예약만 처리 가능)
+     * - Reservation 엔티티의 confirm() 메소드 호출
+     */
+    @Transactional
+    public void confirmReservation(Long reservationId, Long ownerUserId) {
+        // 1. 원장님(OWNER) 권한 검증
+        User user = userReader.read(ownerUserId);
 
+        if (user.getUserType() != UserType.OWNER) {
+            throw new IllegalStateException("예약 확정 권한이 없습니다. (OWNER만 가능)");
+        }
 
+        // 2. 예약 엔티티 조회 및 샵 일치 여부 확인
+        Reservation reservation = reservationReader.getById(reservationId);
 
-    // 2. 원장님 예약 확정 로직 (Update)
+        // 3. 샵 일치 검증: 예약된 샵 ID(Reservation.shopId)와 현재 원장님 ID가 일치하는지 확인
+        if (!reservation.getShopId().equals(ownerUserId)) {
+            throw new IllegalStateException("해당 샵의 예약에 대한 처리 권한이 없습니다.");
+        }
+
+        log.info("예약 ID: {} - 상태 변경 전: {}", reservationId, reservation.getStatus());
+
+        reservation.confirm();
+        log.info("예약 ID: {} - 상태 변경 후: {}", reservationId, reservation.getStatus());
+    }
+
     // 3. 예약 취소 및 거절 로직 (Update)
     // 4. 고객 예약 내역 조회 로직 (Read)
     // 5. 원장님 샵 예약 목록 조회 로직 (Read)

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -15,13 +15,17 @@ import com.example.easybooking.user.domain.UserType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
+
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 @Service
@@ -74,7 +78,19 @@ public class ReservationService {
         LocalTime time = LocalTime.parse(timeString);
 
         // 디자인 사진 URL 추출
-        String designImageURL = formData.get("photo");
+        String photoJsonString = formData.get("photo");
+        List<String> designImageURLs;
+
+        if (photoJsonString == null || photoJsonString.trim().isEmpty()) {
+            designImageURLs = Collections.emptyList();
+        } else {
+            try {
+                designImageURLs = objectMapper.readValue(photoJsonString, new TypeReference<List<String>>() {});
+            } catch (JsonProcessingException e) {
+                throw new IllegalArgumentException("첨부 사진(photo) 데이터 형식이 올바르지 않습니다. JSON 배열 형식이어야 합니다.");
+            }
+        }
+
 
         Reservation newReservation = Reservation.createReservation(
                 shopId,
@@ -83,7 +99,7 @@ public class ReservationService {
                 date,
                 time,
                 formDataJson,
-                designImageURL
+                designImageURLs
         );
 
         Reservation savedReservation = reservationWriter.save(newReservation);
@@ -145,6 +161,10 @@ public class ReservationService {
 
         // TODO: 고객에게 거절 알림
     }
+
+    /**
+     * 고객 전용: 내 예약 내역 조회
+     */
 
 
     // 3. 예약 취소 및 거절 로직 (Update)

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -4,6 +4,7 @@ import com.example.easybooking.reservation.ReservationReader;
 import com.example.easybooking.reservation.ReservationWriter;
 import com.example.easybooking.reservation.domain.Reservation;
 import com.example.easybooking.reservation.dto.ReservationCreateRequest;
+import com.example.easybooking.reservation.dto.ReservationRejectRequest;
 import com.example.easybooking.reservation.dto.ReservationResponse;
 import com.example.easybooking.user.UserReader;
 import com.example.easybooking.user.domain.User;
@@ -87,7 +88,7 @@ public class ReservationService {
      * 3. 예약 거절 로직 (Update)
      */
     @Transactional
-    public void rejectReservation(Long reservationId, Long ownerUserId) {
+    public void rejectReservation(Long reservationId, Long ownerUserId, ReservationRejectRequest request) {
         // 1. 원장님(owner) 권한 검증
         User user = userReader.read(ownerUserId);
         if (user.getUserType() != UserType.OWNER) {
@@ -104,7 +105,7 @@ public class ReservationService {
 
         // 4. 엔티티 상태 변경
         log.info("예약 ID: {} - 거절 전 상태: {}", reservationId, reservation.getStatus());
-        reservation.reject();
+        reservation.reject(request.getReason());
         log.info("예약 ID: {} - 거절 후 상태: {}", reservationId, reservation.getStatus());
 
         // TODO: 고객에게 거절 알림

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -10,12 +10,17 @@ import com.example.easybooking.user.UserReader;
 import com.example.easybooking.user.domain.User;
 import com.example.easybooking.user.domain.UserType;
 import com.example.easybooking.user.service.UserService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.nio.file.AccessDeniedException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -27,8 +32,9 @@ public class ReservationService {
     private final ReservationWriter reservationWriter;   // Writer 주입
     private final ReservationReader reservationReader;   // Reader 주입
     private final UserReader userReader;
-
     private final UserService userService;
+
+    private final ObjectMapper objectMapper;
 
     /**
      * 1. 고객 예약 신청 로직 (Create)
@@ -36,19 +42,45 @@ public class ReservationService {
     @Transactional
     public ReservationResponse createReservation(ReservationCreateRequest request, Long userId) {
         Long customerUserId = userId;
-
         // 현재는 샵 ID와 담담 원장님 ID를 모두 shopId로 설정함. 추후 확장 예정.
         // 현재 shopId는 원장님 User.id
         Long shopId = request.getShopId();
         Long ownerUserId = shopId;
 
+        Map<String, String> formData = request.getFormData();
+        String formDataJson;
+
+        try {
+            formDataJson = objectMapper.writeValueAsString(formData);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("폼 데이터 처리 중 JSON 변환 오류가 발생했습니다.");
+        }
+
+        // 날짜 추출 및 변환
+        String dateString = formData.get("date");
+        if (dateString == null) {
+            throw new IllegalArgumentException(("예약 날짜(date)는 필수 폼 항목입니다."));
+        }
+        LocalDate date = LocalDate.parse(dateString);
+
+        // 시간 추출 및 변환
+        String timeString = formData.get("time");
+        if (timeString == null) {
+            throw new IllegalArgumentException("예약 시간(time)은 필수 폼 항목입니다.");
+        }
+        LocalTime time = LocalTime.parse(timeString);
+
+        // 디자인 사진 URL 추출
+        String designImageURL = formData.get("photo");
+
         Reservation newReservation = Reservation.createReservation(
                 shopId,
                 ownerUserId,
                 customerUserId,
-                request.getDate(),
-                request.getTime(),
-                request.getDesignImageURL()
+                date,
+                time,
+                formDataJson,
+                designImageURL
         );
 
         Reservation savedReservation = reservationWriter.save(newReservation);

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -77,11 +77,39 @@ public class ReservationService {
             throw new IllegalStateException("해당 샵의 예약에 대한 처리 권한이 없습니다.");
         }
 
+        // 4. 엔티티 상태 변경
         log.info("예약 ID: {} - 상태 변경 전: {}", reservationId, reservation.getStatus());
-
         reservation.confirm();
         log.info("예약 ID: {} - 상태 변경 후: {}", reservationId, reservation.getStatus());
     }
+
+    /**
+     * 3. 예약 거절 로직 (Update)
+     */
+    @Transactional
+    public void rejectReservation(Long reservationId, Long ownerUserId) {
+        // 1. 원장님(owner) 권한 검증
+        User user = userReader.read(ownerUserId);
+        if (user.getUserType() != UserType.OWNER) {
+            throw new IllegalStateException("예약 거절 권한이 없습니다. (OWNER만 가능)");
+        }
+
+        // 2. 예약 엔티티 조회 및 샵 일치 여부 확인
+        Reservation reservation = reservationReader.getById(reservationId);
+
+        // 3. 샵 일치 검정
+        if (!reservation.getShopId().equals(ownerUserId)) {
+            throw new IllegalStateException("해당 샵의 예약에 대한 처리 권한이 없습니다.");
+        }
+
+        // 4. 엔티티 상태 변경
+        log.info("예약 ID: {} - 거절 전 상태: {}", reservationId, reservation.getStatus());
+        reservation.reject();
+        log.info("예약 ID: {} - 거절 후 상태: {}", reservationId, reservation.getStatus());
+
+        // TODO: 고객에게 거절 알림
+    }
+
 
     // 3. 예약 취소 및 거절 로직 (Update)
     // 4. 고객 예약 내역 조회 로직 (Read)

--- a/src/main/java/com/example/easybooking/shop/service/ShopService.java
+++ b/src/main/java/com/example/easybooking/shop/service/ShopService.java
@@ -1,20 +1,33 @@
 package com.example.easybooking.shop.service;
 
+import com.example.easybooking.form.FormService;
 import com.example.easybooking.shop.ShopReader;
 import com.example.easybooking.shop.ShopWriter;
 import com.example.easybooking.shop.dto.CreateShopRequest;
 import com.example.easybooking.shop.dto.CreateShopResponse;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
 @RequiredArgsConstructor
 public class ShopService {
     private final ShopWriter shopwriter;
+    private final FormService formService;
+    private static final Logger log = LoggerFactory.getLogger(ShopService.class);
 
     @Transactional
     public CreateShopResponse createShop(Long ownerId, CreateShopRequest request) {
-        return shopwriter.create(ownerId,request);
+        CreateShopResponse response = shopwriter.create(ownerId, request);
+        Long shopId = response.getShopId();
+
+        // Shop 생성 트랜잭션 내에서 Form 엔티티 생성
+        formService.createDefaultForm(shopId);
+        log.info("Shop ID: {} - 기본 폼 생성 완료 및 할당", shopId);
+
+        return response;
     }
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#39

## 📝 요약(Summary)

- 점주(OWNER)가 예약을 확정 또는 거절하는 API 구현
- 점주가 본인의 shop을 생성(등록)할 때 기본 폼이 할당되도록 함
- 고객이 예약을 할 때 해당 shop의 폼에 맞게 예약할 수 있도록 수정
- 폼 조회 시 점주는 본인 shop의 폼만 조회 / 고객은 해당 shop의 폼 조회하도록 수정.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
