### PR TITLE
feat : 예약 조회 api 구현

### DIFF
--- a/src/main/java/com/example/easybooking/reservation/ReservationReader.java
+++ b/src/main/java/com/example/easybooking/reservation/ReservationReader.java
@@ -5,6 +5,9 @@ import com.example.easybooking.reservation.domain.repository.ReservationReposito
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class ReservationReader {
@@ -17,6 +20,25 @@ public class ReservationReader {
     public Reservation getById(Long id) {
         return reservationRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("예약 ID를 찾을 수 없습니다: " + id));
+    }
+
+    // 1. 고객 ID로 모든 예약 목록 조회
+    public List<Reservation> findByCustomerId(Long customerId) {
+        return reservationRepository.findByCustomerId(customerId);
+    }
+
+    // 2. 샵 ID로 모든 예약 목록 조회 (점주용)
+    public List<Reservation> findByShopId(Long shopId) {
+        return reservationRepository.findByShopId(shopId);
+    }
+
+    // 3. 샵 ID와 날짜로 예약 목록 조회 (고객용: 예약 가능 시간 확인)
+    public List<Reservation> findByShopIdAndDate(Long shopId, LocalDate date) {
+        return reservationRepository.findByShopIdAndDate(shopId, date);
+    }
+
+    public List<Reservation> findByShopIdIn(List<Long> shopIds) {
+        return reservationRepository.findByShopIdIn(shopIds);
     }
 
 

--- a/src/main/java/com/example/easybooking/reservation/ReservationReader.java
+++ b/src/main/java/com/example/easybooking/reservation/ReservationReader.java
@@ -41,6 +41,8 @@ public class ReservationReader {
         return reservationRepository.findByShopIdIn(shopIds);
     }
 
-
-
+    // 4. 샵 ID와 채팅방 내 고객 ID(CUSTOMER ID)로 예약 목록 조회 (점주용)
+    public List<Reservation> findByShopIdAndCustomerId(Long shopId, Long customerId) {
+        return reservationRepository.findByShopIdAndCustomerId(shopId, customerId);
+    }
 }

--- a/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationRepository.java
@@ -3,5 +3,18 @@ package com.example.easybooking.reservation.domain.repository;
 import com.example.easybooking.reservation.domain.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    // 1. 고객 ID로 모든 예약 목록 조회
+    List<Reservation> findByCustomerId(Long customerId);
+
+    // 2. 샵 ID로 모든 예약 목록 조회 (점주용)
+    List<Reservation> findByShopId(Long shopId);
+
+    // 3. 샵 ID와 날짜로 예약 목록 조회 (고객용: 예약 가능 시간 확인)
+    List<Reservation> findByShopIdAndDate(Long shopId, LocalDate date);
+    List<Reservation> findByShopIdIn(List<Long> shopIds);
 }

--- a/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationRepository.java
@@ -17,4 +17,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     // 3. 샵 ID와 날짜로 예약 목록 조회 (고객용: 예약 가능 시간 확인)
     List<Reservation> findByShopIdAndDate(Long shopId, LocalDate date);
     List<Reservation> findByShopIdIn(List<Long> shopIds);
+
+    // 4. 샵 ID와 채팅방 내의 고객 ID(CUSTOMER ID)로 예약 목록 조회 (점주용)
+    List<Reservation> findByShopIdAndCustomerId(Long shopId, Long customerId);
 }

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationAvailabilityResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationAvailabilityResponse.java
@@ -1,0 +1,15 @@
+package com.example.easybooking.reservation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class ReservationAvailabilityResponse {
+    private LocalDate date;
+    private List<LocalTime> bookedTimes;   // 예약이 확정된 시간 목록 (예약 불가 시간)
+}

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationCustomerResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationCustomerResponse.java
@@ -1,0 +1,47 @@
+package com.example.easybooking.reservation.dto;
+
+import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.shop.ShopReader;
+import com.example.easybooking.shop.domain.Shop;
+import com.example.easybooking.user.UserReader;
+import com.example.easybooking.user.domain.User;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Data
+@Builder
+public class ReservationCustomerResponse {
+    private Long id;
+    private String shopName;        // 샵 이름 (Shop 엔티티에서 조회)
+    private String customerName;    // 고객 이름 (User 엔티티에서 조회)
+    private Reservation.Status status;
+    private LocalDate date;
+    private LocalTime time;
+    private int photoCount;         // 첨부 사진 갯수
+
+    public static ReservationCustomerResponse from(Reservation reservation, UserReader userReader, ShopReader shopReader) {
+        // 1. 고객 이름 조회
+        User customer = userReader.read(reservation.getCustomerId());
+        String customerName = customer.getName();
+
+        // 2. 샵 이름 조회
+        Shop shop = shopReader.read(reservation.getShopId());
+        String shopName = shop.getBusinessName();
+
+        // 3. 사진 개수 계산
+        int photoCount = reservation.getDesignImageURLs().size();
+
+        return ReservationCustomerResponse.builder()
+                .id(reservation.getId())
+                .shopName(shopName)
+                .customerName(customerName)
+                .status(reservation.getStatus())
+                .date(reservation.getDate())
+                .time(reservation.getTime())
+                .photoCount(photoCount)
+                .build();
+    }
+}

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationOwnerResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationOwnerResponse.java
@@ -1,0 +1,44 @@
+package com.example.easybooking.reservation.dto;
+
+import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.user.UserReader;
+import com.example.easybooking.user.domain.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Data
+@Builder
+public class ReservationOwnerResponse {
+    private Long id;
+    private String customerName;
+    private String customerPhone;
+    private Reservation.Status status;
+    private LocalDate date;
+    private LocalTime time;
+    private int photoCount;           // 첨부 사진 갯수
+    private List<String> photoUrls;   // 첨부 사진 URL 목록
+
+    public static ReservationOwnerResponse from(Reservation reservation, UserReader userReader) {
+        // 1. 고객 정보 조회
+        User customer = userReader.read(reservation.getCustomerId());
+
+        // 2. 사진 URL 목록 조회
+        List<String> photoUrls = reservation.getDesignImageURLs();
+
+        return ReservationOwnerResponse.builder()
+                .id(reservation.getId())
+                .customerName(customer.getName())
+                .customerPhone(customer.getPhoneNumber())
+                .status(reservation.getStatus())
+                .date(reservation.getDate())
+                .time(reservation.getTime())
+                .photoCount(photoUrls.size())
+                .photoUrls(photoUrls)
+                .build();
+    }
+}

--- a/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
+++ b/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
@@ -116,6 +116,25 @@ public class ReservationController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 고객용: 채팅방 내의 특정 샵에 자신이 했던 예약 내역 조회
+     */
+    @GetMapping("/chat/customer")
+    public ResponseEntity<List<ReservationCustomerResponse>> getCustomerReservationInChat(
+            @RequestParam Long shopId,
+            @RequireAuthenticatedUser AuthenticatedUser authenticatedUser) {
+
+        Long customerUserId = authenticatedUser.getUserId();
+
+        List<ReservationCustomerResponse> response =
+                reservationService.getCustomerReservationInChat(customerUserId, shopId);
+
+        return ResponseEntity.ok(response);
+    }
+
+
+
+
     // TODO: [GET] 고객 예약 내역 조회 API
     // TODO: [PUT] 예약 취소/거절 API
 }

--- a/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
+++ b/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
@@ -117,6 +117,7 @@ public class ReservationController {
     }
 
     /**
+     * 채팅방 내 예약 내역 조회
      * 고객용: 채팅방 내의 특정 샵에 자신이 했던 예약 내역 조회
      */
     @GetMapping("/chat/customer")
@@ -128,6 +129,24 @@ public class ReservationController {
 
         List<ReservationCustomerResponse> response =
                 reservationService.getCustomerReservationInChat(customerUserId, shopId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 채팅방 내 예약 내역 조회
+     * 점주용: 채팅방 내의 특정 고객 예약 내역 조회
+     */
+    @GetMapping("/chat/owner")
+    public ResponseEntity<List<ReservationOwnerResponse>> getOwnerReservationsForCustomer(
+            @RequestParam Long shopId,
+            @RequestParam Long customerId,
+            @RequireAuthenticatedUser AuthenticatedUser authenticatedUser) {
+
+        Long ownerUserId = authenticatedUser.getUserId();
+
+        List<ReservationOwnerResponse> response =
+                reservationService.getOwnerReservationsForCustomer(ownerUserId, shopId, customerId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
+++ b/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
@@ -2,19 +2,20 @@ package com.example.easybooking.reservation.presentation;
 
 import com.example.easybooking.auth.AuthenticatedUser;
 import com.example.easybooking.auth.RequireAuthenticatedUser;
-import com.example.easybooking.reservation.dto.ReservationConfirmRequest;
-import com.example.easybooking.reservation.dto.ReservationCreateRequest;
-import com.example.easybooking.reservation.dto.ReservationRejectRequest;
-import com.example.easybooking.reservation.dto.ReservationResponse;
+import com.example.easybooking.reservation.dto.*;
 import com.example.easybooking.reservation.service.ReservationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.apache.coyote.Response;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
+import java.time.LocalDate;
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,6 +73,47 @@ public class ReservationController {
         reservationService.rejectReservation(reservationId, ownerUserId, request);
 
         return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 고객 전용: 내 예약 내역 조회 API
+     */
+    @GetMapping("/my")
+    public ResponseEntity<List<ReservationCustomerResponse>>  getMyReservations(
+            @RequireAuthenticatedUser AuthenticatedUser authenticatedUser) {
+
+        Long customerUserId = authenticatedUser.getUserId();
+
+        List<ReservationCustomerResponse> response = reservationService.getMyReservations(customerUserId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 점주 전용: 샵 예약 목록 조회
+     */
+    @GetMapping("/shop")
+    public ResponseEntity<List<ReservationOwnerResponse>> getShopReservations(
+            @RequireAuthenticatedUser AuthenticatedUser authenticatedUser) {
+
+        Long ownerUserId = authenticatedUser.getUserId();
+
+        List<ReservationOwnerResponse> response = reservationService.getShopReservation(ownerUserId);
+
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 고객용: 샵 예약 가능 시간 조회
+     */
+    @GetMapping("/shop/{shopId}/availability")
+    public ResponseEntity<ReservationAvailabilityResponse> getShopAvailability(
+            @PathVariable Long shopId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+
+        ReservationAvailabilityResponse response = reservationService.getShopAvailability(shopId, date);
+
+        return ResponseEntity.ok(response);
     }
 
     // TODO: [GET] 고객 예약 내역 조회 API

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -214,6 +214,7 @@ public class ReservationService {
     }
 
     /**
+     * 5. 채팅방 내 예약 내역 조회
      * - 고객용: 채팅방 내의 특정 샵에 자신이 했던 예약 내역 조회
      */
     public List<ReservationCustomerResponse> getCustomerReservationInChat(Long customerUserId, Long shopId) {
@@ -226,6 +227,26 @@ public class ReservationService {
 
         return filteredList.stream()
                 .map(r -> ReservationCustomerResponse.from(r, userReader, shopReader))
+                .toList();
+    }
+
+    /**
+     * - 점주용: 채팅방 내의 특정 고객 예약 내역 조회
+     */
+    public List<ReservationOwnerResponse> getOwnerReservationsForCustomer(
+            Long ownerUserId,
+            Long shopId,
+            Long customerId) {
+
+        // 현재 로그인된 사용자가 이 샵의 소유자인지 확인
+        if (!shopReader.isShopOwnedBy(shopId, ownerUserId)) {
+            throw new AccessDeniedException("해당 샵의 예약 내역을 조회할 권한이 없습니다. (소유자 불일치)");
+        }
+
+        List<Reservation> reservations = reservationReader.findByShopIdAndCustomerId(shopId, customerId);
+
+        return reservations.stream()
+                .map(r -> ReservationOwnerResponse.from(r, userReader))
                 .toList();
     }
 

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -213,6 +213,22 @@ public class ReservationService {
         return new ReservationAvailabilityResponse(targetDate, bookedTimes);
     }
 
+    /**
+     * - 고객용: 채팅방 내의 특정 샵에 자신이 했던 예약 내역 조회
+     */
+    public List<ReservationCustomerResponse> getCustomerReservationInChat(Long customerUserId, Long shopId) {
+        List<Reservation> allReservations = reservationReader.findByCustomerId(customerUserId);
+
+        // 채팅방의 shopID와 일치하는 예약만 필터링
+        List<Reservation> filteredList = allReservations.stream()
+                .filter(r -> r.getShopId().equals(shopId))
+                .toList();
+
+        return filteredList.stream()
+                .map(r -> ReservationCustomerResponse.from(r, userReader, shopReader))
+                .toList();
+    }
+
 
     // 3. 예약 취소 및 거절 로직 (Update)
     // 4. 고객 예약 내역 조회 로직 (Read)

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -204,9 +204,10 @@ public class ReservationService {
 
         List<Reservation> reservations = reservationReader.findByShopIdAndDate(shopId, targetDate);
 
-        // 확정(CONFIRMED) 상태의 예약 시간만 추출
+        // 🌟 취소와 거절 상태를 제외한 예약 시간 추출
         List<LocalTime> bookedTimes = reservations.stream()
-                .filter(r -> r.getStatus() == Reservation.Status.CONFIRMED)
+                .filter(r -> r.getStatus() != Reservation.Status.CANCELED &&
+                        r.getStatus() != Reservation.Status.REJECTED)
                 .map(Reservation::getTime)
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -3,10 +3,7 @@ package com.example.easybooking.reservation.service;
 import com.example.easybooking.reservation.ReservationReader;
 import com.example.easybooking.reservation.ReservationWriter;
 import com.example.easybooking.reservation.domain.Reservation;
-import com.example.easybooking.reservation.dto.ReservationConfirmRequest;
-import com.example.easybooking.reservation.dto.ReservationCreateRequest;
-import com.example.easybooking.reservation.dto.ReservationRejectRequest;
-import com.example.easybooking.reservation.dto.ReservationResponse;
+import com.example.easybooking.reservation.dto.*;
 import com.example.easybooking.shop.ShopReader;
 import com.example.easybooking.shop.domain.Shop;
 import com.example.easybooking.user.UserReader;
@@ -27,6 +24,7 @@ import java.time.LocalTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -163,8 +161,57 @@ public class ReservationService {
     }
 
     /**
-     * 고객 전용: 내 예약 내역 조회
+     * 4. 예약 내역 조회
+     * - 고객 전용: 내 예약 내역 조회
      */
+    public List<ReservationCustomerResponse> getMyReservations(Long customerUserId) {
+        List<Reservation> reservations = reservationReader.findByCustomerId(customerUserId);
+
+        return reservations.stream()
+                .map(r -> ReservationCustomerResponse.from(r, userReader, shopReader))
+                .toList();
+    }
+
+    /**
+     * - 점주 젼용: 샵 예약 목록 조회
+     */
+    public List<ReservationOwnerResponse> getShopReservation(Long ownerUserId) {
+        // 점주 권한 검증
+        User user = userReader.read(ownerUserId);
+        if (user.getUserType() != UserType.OWNER) {
+            throw new AccessDeniedException("샵 예약 목록 조회 권한이 없습니다. (OWNER만 가능)");
+        }
+
+        // ownerUserId에 연결된 샵 ID 목록을 가져옴
+        List<Long> shopIds = shopReader.findShopIdsByOwnerId(ownerUserId);
+
+        if (shopIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Reservation> reservations = reservationReader.findByShopIdIn(shopIds);
+
+        return reservations.stream()
+                .map(r -> ReservationOwnerResponse.from(r, userReader))
+                .toList();
+    }
+
+    /**
+     * - 고객용: 샵 예약 가능 시간 조회
+     */
+    public ReservationAvailabilityResponse getShopAvailability(Long shopId, LocalDate date) {
+        LocalDate targetDate = (date != null) ? date : LocalDate.now();
+
+        List<Reservation> reservations = reservationReader.findByShopIdAndDate(shopId, targetDate);
+
+        // 확정(CONFIRMED) 상태의 예약 시간만 추출
+        List<LocalTime> bookedTimes = reservations.stream()
+                .filter(r -> r.getStatus() == Reservation.Status.CONFIRMED)
+                .map(Reservation::getTime)
+                .collect(Collectors.toList());
+
+        return new ReservationAvailabilityResponse(targetDate, bookedTimes);
+    }
 
 
     // 3. 예약 취소 및 거절 로직 (Update)

--- a/src/main/java/com/example/easybooking/shop/ShopReader.java
+++ b/src/main/java/com/example/easybooking/shop/ShopReader.java
@@ -6,6 +6,9 @@ import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RequiredArgsConstructor
 @Component
 public class ShopReader {
@@ -18,5 +21,11 @@ public class ShopReader {
     public Shop read(Long id){
         return shopRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid shop ID"));
+    }
+
+    public List<Long> findShopIdsByOwnerId(Long ownerId) {
+        return shopRepository.findAllByOwnerId(ownerId).stream()
+                .map(Shop::getId)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/example/easybooking/shop/ShopReader.java
+++ b/src/main/java/com/example/easybooking/shop/ShopReader.java
@@ -28,4 +28,8 @@ public class ShopReader {
                 .map(Shop::getId)
                 .collect(Collectors.toList());
     }
+
+    public boolean isShopOwnedBy(Long shopId, Long ownerUserId) {
+        return shopRepository.existsByIdAndOwnerId(shopId, ownerUserId);
+    }
 }

--- a/src/main/java/com/example/easybooking/shop/repository/ShopRepository.java
+++ b/src/main/java/com/example/easybooking/shop/repository/ShopRepository.java
@@ -3,6 +3,10 @@ package com.example.easybooking.shop.repository;
 import com.example.easybooking.shop.domain.Shop;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ShopRepository extends JpaRepository<Shop, Long> {
+    List<Shop> findAllByOwnerId(Long ownerId);
+
     boolean existsByOwnerId(Long ownerId);
 }

--- a/src/main/java/com/example/easybooking/shop/repository/ShopRepository.java
+++ b/src/main/java/com/example/easybooking/shop/repository/ShopRepository.java
@@ -8,5 +8,7 @@ import java.util.List;
 public interface ShopRepository extends JpaRepository<Shop, Long> {
     List<Shop> findAllByOwnerId(Long ownerId);
 
+    boolean existsByIdAndOwnerId(Long shopId, Long ownerId);
+
     boolean existsByOwnerId(Long ownerId);
 }


### PR DESCRIPTION
## #️⃣ Issue Number

#50

## 📝 요약(Summary)

- 개인 예약 조회 (고객용) : 해당 사용자의 모든 예약 내역을 조회하는 API 구현.

- 샵 예약 조회 (점주용) : Owner ID를 기준으로 샵 ID를 조회한 후, 해당 샵의 예약 내역을 가져오도록 구현.

- 예약 가능 시간 조회 (고객용) : 특정 샵 ID와 날짜를 기반으로 해당 샵의 이미 확정된 예약의 시간대 목록을 제공하는 API 구현. -> 왜 구현했나? 고객이 특정 샵 예약 시에, 해당 샵의 이미 확정된 예약의 시간대를 조회할 수 있도록 하기 위함.

- 채팅방 내 예약 내역 조회(고객용) : 채팅 중인 특정 샵에 대해 본인이 했던 예약 내역만 조회하는 API 구현
- 채팅방 내 예약 내역 조회(점주용) : 채팅 중인 특정 고객과의 예약 내역만 조회하는 API 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
