### PR TITLE
refactor : 로컬 프론트 테스트를 위한 API 구현

### DIFF
--- a/src/main/java/com/example/easybooking/auth/KakaoUtil.java
+++ b/src/main/java/com/example/easybooking/auth/KakaoUtil.java
@@ -20,10 +20,8 @@ public class KakaoUtil {
 
     @Value("${spring.kakao.auth.client}")
     private String client;
-    @Value("${spring.kakao.auth.redirect}")
-    private String redirect;
 
-    public KakaoDto.OAuthToken requestToken(String accessCode) {
+    public KakaoDto.OAuthToken requestToken(String accessCode, String redirect_uri) {
         RestTemplate restTemplate = new RestTemplate();
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
@@ -31,7 +29,7 @@ public class KakaoUtil {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
         params.add("client_id", client);
-        params.add("redirect_uri", redirect);
+        params.add("redirect_uri", redirect_uri);
         params.add("code", accessCode);
 
         HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
@@ -53,8 +51,8 @@ public class KakaoUtil {
         return oAuthToken;
     }
 
-    public KakaoDto.KakaoId requestKakaoId(String accessCode){
-        KakaoDto.OAuthToken oAuthToken = requestToken(accessCode);
+    public KakaoDto.KakaoId requestKakaoId(String accessCode,String redirect_url){
+        KakaoDto.OAuthToken oAuthToken = requestToken(accessCode,redirect_url);
         RestTemplate restTemplate2 = new RestTemplate();
         HttpHeaders headers2 = new HttpHeaders();
 

--- a/src/main/java/com/example/easybooking/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/easybooking/auth/presentation/AuthController.java
@@ -3,6 +3,7 @@ package com.example.easybooking.auth.presentation;
 import com.example.easybooking.auth.dto.AuthResponse;
 import com.example.easybooking.auth.service.AuthService;
 import com.example.easybooking.auth.dto.KakaoAccessCodeRequest;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,9 +17,27 @@ import lombok.extern.slf4j.Slf4j;
 public class AuthController {
     private final AuthService authService;
 
+    @Value("${spring.kakao.auth.redirect}")
+    private String redirect;
+
+    @Value("${spring.kakao.auth.redirect-local}")
+    private String redirectLocal;
+
     @PostMapping("/oauth/login/kakao")
     public ResponseEntity<AuthResponse> kakaoLogin(@RequestBody KakaoAccessCodeRequest request) {
-        AuthResponse response = authService.oAuthLogin(request.getAccessCode());
+        AuthResponse response = authService.oAuthLogin(request.getAccessCode(),redirect);
+        if (response.getAccessToken() != null) {
+            log.info("카카오 로그인 성공: 엑세스 토큰={}", response.getAccessToken());
+            return ResponseEntity.ok(response);
+        } else {
+            log.error("카카오 로그인 실패: {}", response.getMessage());
+            return ResponseEntity.badRequest().body(response);
+        }
+    }
+
+    @PostMapping("/oauth/login/kakao/local")
+    public ResponseEntity<AuthResponse> kakaoLoginForLocal(@RequestBody KakaoAccessCodeRequest request) {
+        AuthResponse response = authService.oAuthLogin(request.getAccessCode(),redirectLocal);
         if (response.getAccessToken() != null) {
             log.info("카카오 로그인 성공: 엑세스 토큰={}", response.getAccessToken());
             return ResponseEntity.ok(response);

--- a/src/main/java/com/example/easybooking/auth/service/AuthService.java
+++ b/src/main/java/com/example/easybooking/auth/service/AuthService.java
@@ -19,9 +19,9 @@ public class AuthService {
     private final UserReader userReader;
     private final JwtUtil jwtUtil;
 
-    public AuthResponse oAuthLogin(String accessCode) {
+    public AuthResponse oAuthLogin(String accessCode,String redirect_uri) {
         try {
-            KakaoDto.KakaoId kakaoId = kakaoUtil.requestKakaoId(accessCode);
+            KakaoDto.KakaoId kakaoId = kakaoUtil.requestKakaoId(accessCode,redirect_uri);
             Optional<User> existingUser = userReader.getUserByProviderId(String.valueOf(kakaoId.getId()));
 
             if (existingUser.isPresent()) {

--- a/src/main/java/com/example/easybooking/config/SecurityConfig.java
+++ b/src/main/java/com/example/easybooking/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
     public static final String[] allowUrls = {
             "/login",
             "/oauth/login/kakao",
+            "/oauth/login/kakao/local",
             "/v3/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,7 @@ spring:
     auth:
       client: ${KAKAO_CLIENT_ID}
       redirect: http://localhost:8080/oauth/login/kakao
+      redirect-local: http://localhost:5173/auth
 jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-expiration: 31536000000  # 로컬 테스트용, 유효기간 1년

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,7 +61,8 @@ spring:
   kakao:
     auth:
       client: ${KAKAO_CLIENT_ID}
-      redirect: http://localhost:5173/auth
+      redirect-local: http://localhost:5173/auth
+      redirect: https://ssnapbook.netlify.app/auth
 jwt:
   secret: ${JWT_SECRET_KEY}
   access-token-expiration: 31536000000 # 배포 테스트용


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

#54 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

현재 카카오 OAuth는 인가코드 발급과 토큰 발급 요청에 redirect_url을 포함시킨다.

그리고 이 둘은 정확히 일치해야한다.

카카오 인증서버 측에서 클라이언트를 redirect_url에 리다이렉트를 시켜 인가코드를 보내주는 방식인데,

여기서 문제가 생겼다.

배포된 백엔드 서버는 당연히 토큰 발급 시, 배포된 프론트 auth 경로로 redirect_url을 파라미터로 설정하기 때문에

로컬 프론트에서 테스트를 위해서 local 경로를 redirect_url을 파라미터로 두었을 시, 카카오 로그인에서 koe303 에러가 뜬다
(redirect_url mismatch)

따라서 로컬 프론트를 위한 api를 하나 더 만들어서 토큰 발급 시, 로컬 프론트의 redirect_url 경로에 맞게 요청해야한다.

현재 application.yml에 두 가지의 링크를 두고 컨트롤러에서 서비스로 넘어갈 때 넘겨주는 방식으로 구현했다. 

빠른 개발이 필요하기 때문에 임시방편이라 생각하면 되겠다.


## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
