### PR TITLE
fix : 빈 리스트 접근 방지 로직 구현

### DIFF
--- a/src/main/java/com/example/easybooking/chat/MessageReader.java
+++ b/src/main/java/com/example/easybooking/chat/MessageReader.java
@@ -23,8 +23,10 @@ public class MessageReader {
         List<Message> messages;
         if (cursorId == null) {
             messages = messageRepository.findLatestMessages(chatRoom.getId(), size);
-            chatRoom.updateLastReadMessageId(messages.get(0).getId(), userId);
-            chatRoomRepository.save(chatRoom);
+            if (!messages.isEmpty()) {
+                chatRoom.updateLastReadMessageId(messages.get(0).getId(), userId);
+                chatRoomRepository.save(chatRoom);
+            }
         } else {
             messages = messageRepository.findMessagesBeforeCursor(chatRoom.getId(), cursorId, size);
         }


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

#60 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

현재 채팅방 접근 시, 메시지 히스토리 조회 api가 호출된다.

해당 api 호출 시, 메시지 리스트를 불러오고 가장 최신 메시지의 id를 가져와

채팅방의 lastReadMessageId를 업데이트한다.

하지만 채팅방 최초 생성 시, 메시지 리스트는 비어있으므로 IndexOutofBoundException이 발생한다.

따라서 빈 리스트 체크 로직을 구현하였다.

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
