### PR TITLE
feat : 예약 조회 응답에 createdAt 추가

### DIFF
--- a/src/main/java/com/example/easybooking/form/FormInitializer.java
+++ b/src/main/java/com/example/easybooking/form/FormInitializer.java
@@ -30,7 +30,9 @@ public class FormInitializer {
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
     public void initializeDefaultForm() {
-        if (formRepository.findByName("시스템 기본 폼").isPresent()) {
+        List<Form> existingForms = formRepository.findByName("시스템 기본 폼");
+
+        if (!existingForms.isEmpty()) {
             return;
         }
 

--- a/src/main/java/com/example/easybooking/form/FormReader.java
+++ b/src/main/java/com/example/easybooking/form/FormReader.java
@@ -7,6 +7,8 @@ import com.example.easybooking.form.domain.repository.FormRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class FormReader {
@@ -18,8 +20,11 @@ public class FormReader {
     }
 
     public Form readDefaultForm() {
-        return formRepository.findByName("시스템 기본 폼")
-                .orElseThrow(() -> new FormException(FormErrorCode.DEFAULT_FORM_NOT_FOUND));
+        List<Form> forms = formRepository.findByName("시스템 기본 폼");
+        if (forms.isEmpty()) {
+            throw new FormException(FormErrorCode.DEFAULT_FORM_NOT_FOUND);
+        }
+        return forms.get(0);
     }
 
     public Form readByShopId(Long shopId) {

--- a/src/main/java/com/example/easybooking/form/domain/repository/FormRepository.java
+++ b/src/main/java/com/example/easybooking/form/domain/repository/FormRepository.java
@@ -3,9 +3,11 @@ package com.example.easybooking.form.domain.repository;
 import com.example.easybooking.form.domain.Form;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FormRepository extends JpaRepository<Form,Long> {
     Optional<Form> findByShopId(Long shopId);
-    Optional<Form> findByName(String title);
+    // Optional<Form> findByName(String title);
+    List<Form> findByName(String name);
 }

--- a/src/main/java/com/example/easybooking/reservation/domain/Reservation.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/Reservation.java
@@ -20,6 +20,7 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 @Entity
 @Table(name = "reservations")
@@ -52,6 +53,7 @@ public class Reservation {
     @Column(name = "photo_url")
     private List<String> designImageURLs = new ArrayList<>();
 
+    @CreationTimestamp
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationCustomerResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationCustomerResponse.java
@@ -6,7 +6,10 @@ import com.example.easybooking.shop.domain.Shop;
 import com.example.easybooking.user.UserReader;
 import com.example.easybooking.user.domain.User;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
+
 import lombok.Builder;
 import lombok.Data;
 
@@ -19,8 +22,9 @@ public class ReservationCustomerResponse {
     private Reservation.Status status;
     private LocalDate date;
     private LocalTime time;
-    private int photoCount;         // 첨부 사진 갯수
-    // TODO: 첨부 사진 URL 리스트 필요
+    private int photoCount;          // 첨부 사진 갯수
+    private List<String> photoUrls;  // 첨부 사진 URL 목록
+    private LocalDateTime createdAt;
 
     public static ReservationCustomerResponse from(Reservation reservation, UserReader userReader,
                                                    ShopReader shopReader) {
@@ -43,6 +47,8 @@ public class ReservationCustomerResponse {
                 .date(reservation.getDate())
                 .time(reservation.getTime())
                 .photoCount(photoCount)
+                .photoUrls(reservation.getDesignImageURLs())
+                .createdAt(reservation.getCreatedAt())
                 .build();
     }
 }

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationOwnerResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationOwnerResponse.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -22,6 +23,7 @@ public class ReservationOwnerResponse {
     private LocalTime time;
     private int photoCount;           // 첨부 사진 갯수
     private List<String> photoUrls;   // 첨부 사진 URL 목록
+    private LocalDateTime createdAt;
 
     public static ReservationOwnerResponse from(Reservation reservation, UserReader userReader) {
         // 1. 고객 정보 조회
@@ -39,6 +41,7 @@ public class ReservationOwnerResponse {
                 .time(reservation.getTime())
                 .photoCount(photoUrls.size())
                 .photoUrls(photoUrls)
+                .createdAt(reservation.getCreatedAt())
                 .build();
     }
 }


### PR DESCRIPTION
- 채팅방 내 예약 목록의 시간순 정렬을 위해 예약 응답 DTO에 LocalDateTime createdAt 필드 추가

## #️⃣ Issue Number

#74 

## 📝 요약(Summary)



## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reservations now automatically track creation timestamps.
  * Reservation details now display when a reservation was created.
  * Customer reservation summaries now include design photo URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->