### PR TITLE
refactor: reservation 조회 로직 정리 및 N+1 개선

### DIFF
--- a/src/main/java/com/example/easybooking/reservation/ReservationReader.java
+++ b/src/main/java/com/example/easybooking/reservation/ReservationReader.java
@@ -29,6 +29,11 @@ public class ReservationReader {
         return reservationRepository.findByCustomerIdOrderByCreatedAtDesc(customerId);
     }
 
+    // 1-1. 고객 ID + 샵 ID로 예약 목록 조회 (최신순 정렬) - 채팅방 내 예약 조회용
+    public List<Reservation> findByCustomerIdAndShopId(Long customerId, Long shopId) {
+        return reservationRepository.findByCustomerIdAndShopIdOrderByCreatedAtDesc(customerId, shopId);
+    }
+
     // 2. 샵 ID로 모든 예약 목록 조회 (점주용)
     public List<Reservation> findByShopId(Long shopId) {
         return reservationRepository.findByShopId(shopId);

--- a/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationRepository.java
@@ -15,6 +15,9 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     // 1. 고객 ID로 모든 예약 목록 조회 (최신순 정렬)
     List<Reservation> findByCustomerIdOrderByCreatedAtDesc(Long customerId);
 
+    // 1-1. 고객 ID + 샵 ID로 예약 목록 조회 (최신순 정렬) - 채팅방 내 예약 조회용
+    List<Reservation> findByCustomerIdAndShopIdOrderByCreatedAtDesc(Long customerId, Long shopId);
+
     // 2. 샵 ID로 모든 예약 목록 조회 (점주용)
     List<Reservation> findByShopId(Long shopId);
 

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationCustomerResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationCustomerResponse.java
@@ -53,12 +53,18 @@ public class ReservationCustomerResponse {
         // 2. 샵 이름 조회
         Shop shop = shopReader.read(reservation.getShopId());
         String shopName = shop.getBusinessName();
+        return from(reservation, customerName, shopName, formData);
+    }
 
-        // 3. 사진 URL 목록 조회 및 개수 계산
+    public static ReservationCustomerResponse from(
+            Reservation reservation,
+            String customerName,
+            String shopName,
+            Map<String, String> formData
+    ) {
         List<String> photoUrls = reservation.getDesignImageURLs();
         int photoCount = photoUrls.size();
 
-        // 4. 폼 데이터에서 상세 필드 추출 및 계산
         String part = formData.get("part");
         String removal = formData.get("removal");
         String requests = formData.get("requests");
@@ -77,11 +83,10 @@ public class ReservationCustomerResponse {
                 .date(reservation.getDate())
                 .time(reservation.getTime())
                 .photoCount(photoCount)
-                .photoUrls(reservation.getDesignImageURLs())
+                .photoUrls(photoUrls)
                 .rejectionReason(reservation.getRejectionReason())
                 .confirmationMessage(reservation.getConfirmationMessage())
                 .createdAt(reservation.getCreatedAt())
-
                 .part(part)
                 .removal(removal)
                 .requests(requests)

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationOwnerResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationOwnerResponse.java
@@ -45,11 +45,20 @@ public class ReservationOwnerResponse {
     ) {
         // 1. 고객 정보 조회
         User customer = userReader.read(reservation.getCustomerId());
+        return from(reservation, customer.getName(), customer.getPhoneNumber(), formData);
+    }
 
-        // 2. 사진 URL 목록 조회
+    public static ReservationOwnerResponse from(
+            Reservation reservation,
+            String customerName,
+            String customerPhone,
+            Map<String, String> formData
+    ) {
+
+        // 사진 URL 목록 조회
         List<String> photoUrls = reservation.getDesignImageURLs();
 
-        // 3. 폼 데이터에서 상세 필드 추출
+        // 폼 데이터에서 상세 필드 추출
         String part = formData.get("part");
         String removal = formData.get("removal");
         String requests = formData.get("requests");
@@ -62,8 +71,8 @@ public class ReservationOwnerResponse {
 
         return ReservationOwnerResponse.builder()
                 .id(reservation.getId())
-                .customerName(customer.getName())
-                .customerPhone(customer.getPhoneNumber())
+                .customerName(customerName)
+                .customerPhone(customerPhone)
                 .status(reservation.getStatus())
                 .date(reservation.getDate())
                 .time(reservation.getTime())

--- a/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
+++ b/src/main/java/com/example/easybooking/reservation/presentation/ReservationController.java
@@ -155,7 +155,7 @@ public class ReservationController {
      * 점주용: 채팅방 내의 특정 고객 예약 내역 조회
      */
     @GetMapping("/chat/owner")
-    public ResponseEntity<List<ReservationOwnerResponse>> getOwnerReservationsForCustomer(
+    public ResponseEntity<List<ReservationOwnerResponse>> getReservationsByCustomerInShop(
             @RequestParam Long shopId,
             @RequestParam Long customerId,
             @RequireAuthenticatedUser AuthenticatedUser authenticatedUser) {
@@ -163,7 +163,7 @@ public class ReservationController {
         Long ownerUserId = authenticatedUser.getUserId();
 
         List<ReservationOwnerResponse> response =
-                reservationService.getOwnerReservationsForCustomer(ownerUserId, shopId, customerId);
+                reservationService.getReservationsByCustomerInShop(ownerUserId, shopId, customerId);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -29,9 +29,11 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
@@ -336,12 +338,25 @@ public class ReservationService {
      */
     public List<ReservationCustomerResponse> getMyReservations(Long customerUserId) {
         List<Reservation> reservations = reservationReader.findByCustomerId(customerUserId);
+        if (reservations.isEmpty()) {
+            return List.of();
+        }
+
+        User customer = userReader.read(customerUserId);
+        String customerName = customer.getName();
+
+        Set<Long> shopIds = reservations.stream()
+                .map(Reservation::getShopId)
+                .collect(Collectors.toSet());
+
+        Map<Long, String> shopNameById = shopReader.readAllByIds(new ArrayList<>(shopIds)).stream()
+                .collect(Collectors.toMap(Shop::getId, Shop::getBusinessName, (a, b) -> a));
 
         return reservations.stream()
                 .map(r -> {
                     Map<String, String> formData = parseFormData(r);
-
-                    return ReservationCustomerResponse.from(r, userReader, shopReader, formData);
+                    String shopName = shopNameById.get(r.getShopId());
+                    return ReservationCustomerResponse.from(r, customerName, shopName, formData);
                 })
                 .toList();
     }

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -431,7 +431,7 @@ public class ReservationService {
     /**
      * - 점주용: 채팅방 내의 특정 고객 예약 내역 조회
      */
-    public List<ReservationOwnerResponse> getOwnerReservationsForCustomer(
+    public List<ReservationOwnerResponse> getReservationsByCustomerInShop(
             Long ownerUserId,
             Long shopId,
             Long customerId) {

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -380,11 +380,19 @@ public class ReservationService {
 
         List<Reservation> reservations = reservationReader.findByShopIdIn(shopIds);
 
+        Set<Long> customerIds = reservations.stream()
+                .map(Reservation::getCustomerId)
+                .collect(Collectors.toSet());
+
+        Map<Long, User> userById = userReader.readAllByIds(new ArrayList<>(customerIds)).stream()
+                .collect(Collectors.toMap(User::getId, u -> u, (a, b) -> a));
+
         return reservations.stream()
                 .map(r -> {
                     Map<String, String> formData = parseFormData(r);
 
-                    return ReservationOwnerResponse.from(r, userReader, formData);
+                    User customer = userById.get(r.getCustomerId());
+                    return ReservationOwnerResponse.from(r, customer.getName(), customer.getPhoneNumber(), formData);
                 })
                 .toList();
     }

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -411,18 +411,19 @@ public class ReservationService {
      * 5. 채팅방 내 예약 내역 조회 - 고객용: 채팅방 내의 특정 샵에 자신이 했던 예약 내역 조회
      */
     public List<ReservationCustomerResponse> getCustomerReservationInChat(Long customerUserId, Long shopId) {
-        List<Reservation> allReservations = reservationReader.findByCustomerId(customerUserId);
+        List<Reservation> reservations = reservationReader.findByCustomerIdAndShopId(customerUserId, shopId);
+        if (reservations.isEmpty()) {
+            return List.of();
+        }
 
-        // 채팅방의 shopID와 일치하는 예약만 필터링
-        List<Reservation> filteredList = allReservations.stream()
-                .filter(r -> r.getShopId().equals(shopId))
-                .toList();
+        // 채팅방 내 "내 예약"이므로 고객/샵 정보는 각각 1번만 조회
+        String customerName = userReader.read(customerUserId).getName();
+        String shopName = shopReader.read(shopId).getBusinessName();
 
-        return filteredList.stream()
+        return reservations.stream()
                 .map(r -> {
                     Map<String, String> formData = parseFormData(r);
-
-                    return ReservationCustomerResponse.from(r, userReader, shopReader, formData);
+                    return ReservationCustomerResponse.from(r, customerName, shopName, formData);
                 })
                 .toList();
     }

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -450,6 +450,13 @@ public class ReservationService {
         }
 
         List<Reservation> reservations = reservationReader.findByShopIdAndCustomerId(shopId, customerId);
+        if (reservations.isEmpty()) {
+            return List.of();
+        }
+
+        User customer = userReader.read(customerId);
+        String customerName = customer.getName();
+        String customerPhone = customer.getPhoneNumber();
 
         return reservations.stream()
                 .map(r -> {
@@ -457,7 +464,7 @@ public class ReservationService {
                     Map<String, String> formData = parseFormData(r);
 
                     // 🌟 DTO.from() 호출 시 파싱된 데이터를 함께 전달
-                    return ReservationOwnerResponse.from(r, userReader, formData);
+                    return ReservationOwnerResponse.from(r, customerName, customerPhone, formData);
                 })
                 .toList();
     }

--- a/src/main/java/com/example/easybooking/shop/ShopReader.java
+++ b/src/main/java/com/example/easybooking/shop/ShopReader.java
@@ -47,4 +47,8 @@ public class ShopReader {
     public boolean isShopOwnedBy(Long shopId, Long ownerUserId) {
         return shopRepository.existsByIdAndOwnerId(shopId, ownerUserId);
     }
+
+    public List<Shop> readAllByIds(List<Long> shopIds) {
+        return shopRepository.findAllById(shopIds);
+    }
 }

--- a/src/main/java/com/example/easybooking/user/UserReader.java
+++ b/src/main/java/com/example/easybooking/user/UserReader.java
@@ -4,6 +4,7 @@ import com.example.easybooking.errors.errorcode.UserErrorCode;
 import com.example.easybooking.errors.exception.UserException;
 import com.example.easybooking.user.domain.User;
 import com.example.easybooking.user.domain.repository.UserRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -19,5 +20,9 @@ public class UserReader {
 
     public User read(Long userId) {
         return userRepository.findById(userId).orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    public List<User> readAllByIds(List<Long> userIds) {
+        return userRepository.findAllById(userIds);
     }
 }

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetCustomerReservationInChatUnitTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetCustomerReservationInChatUnitTest.java
@@ -1,0 +1,123 @@
+package com.example.easybooking.reservation.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.example.easybooking.reservation.ReservationReader;
+import com.example.easybooking.reservation.ReservationWriter;
+import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.reservation.dto.ReservationCustomerResponse;
+import com.example.easybooking.shop.ShopReader;
+import com.example.easybooking.shop.domain.Shop;
+import com.example.easybooking.user.UserReader;
+import com.example.easybooking.user.domain.User;
+import com.example.easybooking.user.domain.UserType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceGetCustomerReservationInChatUnitTest {
+
+    @Mock private ReservationWriter reservationWriter;
+    @Mock private ReservationReader reservationReader;
+    @Mock private UserReader userReader;
+    @Mock private ShopReader shopReader;
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private ReservationService reservationService;
+
+    @BeforeEach
+    void setUp() {
+        reservationService = new ReservationService(
+                reservationWriter,
+                reservationReader,
+                userReader,
+                shopReader,
+                objectMapper,
+                eventPublisher
+        );
+    }
+
+    @Test
+    void getCustomerReservationInChat_예약0건이면_빈리스트_그리고_추가조회없음() {
+        // given
+        long customerId = 1L;
+        long shopId = 2L;
+        when(reservationReader.findByCustomerIdAndShopId(customerId, shopId)).thenReturn(List.of());
+
+        // when
+        List<ReservationCustomerResponse> result = reservationService.getCustomerReservationInChat(customerId, shopId);
+
+        // then
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(userReader);
+        verifyNoInteractions(shopReader);
+    }
+
+    @Test
+    void getCustomerReservationInChat_N건이어도_고객조회1회_샵조회1회_그리고_findByCustomerId는_호출되지않음() throws Exception {
+        // given
+        long customerId = 10L;
+        long shopId = 20L;
+
+        Map<String, String> formData = Map.of(
+                "part", "손",
+                "removal", "예",
+                "requests", "요청",
+                "extend", "0",
+                "wrapping", "0"
+        );
+        String formJson = objectMapper.writeValueAsString(formData);
+
+        Reservation r1 = Reservation.createReservation(
+                shopId, 100L, customerId,
+                LocalDate.parse("2026-01-10"), LocalTime.parse("10:00"),
+                formJson, List.of()
+        );
+        Reservation r2 = Reservation.createReservation(
+                shopId, 100L, customerId,
+                LocalDate.parse("2026-01-11"), LocalTime.parse("11:00"),
+                formJson, List.of()
+        );
+
+        when(reservationReader.findByCustomerIdAndShopId(customerId, shopId)).thenReturn(List.of(r1, r2));
+        when(userReader.read(customerId)).thenReturn(User.createUser("provider-1", "고객", "01000000000", UserType.CUSTOMER));
+
+        Shop shop = Mockito.mock(Shop.class);
+        when(shop.getBusinessName()).thenReturn("샵");
+        when(shopReader.read(shopId)).thenReturn(shop);
+
+        // when
+        List<ReservationCustomerResponse> result = reservationService.getCustomerReservationInChat(customerId, shopId);
+
+        // then
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(x -> "고객".equals(x.getCustomerName())));
+        assertEquals(Set.of("샵"), result.stream().map(ReservationCustomerResponse::getShopName).collect(Collectors.toSet()));
+
+        verify(userReader, times(1)).read(customerId);
+        verify(shopReader, times(1)).read(shopId);
+        verify(reservationReader, never()).findByCustomerId(anyLong());
+    }
+}
+

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetMyReservationsUnitTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetMyReservationsUnitTest.java
@@ -1,0 +1,137 @@
+package com.example.easybooking.reservation.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.example.easybooking.reservation.ReservationReader;
+import com.example.easybooking.reservation.ReservationWriter;
+import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.reservation.dto.ReservationCustomerResponse;
+import com.example.easybooking.shop.ShopReader;
+import com.example.easybooking.shop.domain.Shop;
+import com.example.easybooking.user.UserReader;
+import com.example.easybooking.user.domain.User;
+import com.example.easybooking.user.domain.UserType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceGetMyReservationsUnitTest {
+
+    @Mock private ReservationWriter reservationWriter;
+    @Mock private ReservationReader reservationReader;
+    @Mock private UserReader userReader;
+    @Mock private ShopReader shopReader;
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private ReservationService reservationService;
+
+    @BeforeEach
+    void setUp() {
+        reservationService = new ReservationService(
+                reservationWriter,
+                reservationReader,
+                userReader,
+                shopReader,
+                objectMapper,
+                eventPublisher
+        );
+    }
+
+    @Test
+    void getMyReservations_예약0건이면_빈리스트_그리고_추가조회없음() {
+        // given
+        long customerId = 1L;
+        when(reservationReader.findByCustomerId(customerId)).thenReturn(List.of());
+
+        // when
+        List<ReservationCustomerResponse> result = reservationService.getMyReservations(customerId);
+
+        // then
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(userReader);
+        verifyNoInteractions(shopReader);
+    }
+
+    @Test
+    void getMyReservations_N건이어도_user1회_shop배치1회_단건샵조회0회() throws Exception {
+        // given
+        long customerId = 10L;
+
+        Map<String, String> formData = Map.of(
+                "part", "손",
+                "removal", "예",
+                "requests", "요청",
+                "extend", "0",
+                "wrapping", "0"
+        );
+        String formJson = objectMapper.writeValueAsString(formData);
+
+        Reservation r1 = Reservation.createReservation(
+                1L, 100L, customerId,
+                LocalDate.parse("2026-01-10"), LocalTime.parse("10:00"),
+                formJson, List.of()
+        );
+        Reservation r2 = Reservation.createReservation(
+                2L, 200L, customerId,
+                LocalDate.parse("2026-01-11"), LocalTime.parse("11:00"),
+                formJson, List.of()
+        );
+        Reservation r3 = Reservation.createReservation(
+                1L, 100L, customerId,
+                LocalDate.parse("2026-01-12"), LocalTime.parse("12:00"),
+                formJson, List.of()
+        );
+
+        when(reservationReader.findByCustomerId(customerId)).thenReturn(List.of(r1, r2, r3));
+        when(userReader.read(customerId)).thenReturn(User.createUser("provider-1", "고객", "01000000000", UserType.CUSTOMER));
+
+        Shop s1 = Mockito.mock(Shop.class);
+        when(s1.getId()).thenReturn(1L);
+        when(s1.getBusinessName()).thenReturn("샵1");
+
+        Shop s2 = Mockito.mock(Shop.class);
+        when(s2.getId()).thenReturn(2L);
+        when(s2.getBusinessName()).thenReturn("샵2");
+
+        when(shopReader.readAllByIds(anyList())).thenReturn(List.of(s1, s2));
+
+        // when
+        List<ReservationCustomerResponse> result = reservationService.getMyReservations(customerId);
+
+        // then: 결과 기본 검증
+        assertEquals(3, result.size());
+        assertTrue(result.stream().allMatch(x -> "고객".equals(x.getCustomerName())));
+        assertEquals(
+                Set.of("샵1", "샵2"),
+                result.stream().map(ReservationCustomerResponse::getShopName).collect(Collectors.toSet())
+        );
+
+        // then: N+1 방지 핵심 검증(호출 횟수)
+        verify(userReader, times(1)).read(customerId);
+        verify(shopReader, times(1)).readAllByIds(anyList());
+        verify(shopReader, never()).read(anyLong());
+    }
+}
+

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetReservationsByCustomerInShopUnitTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetReservationsByCustomerInShopUnitTest.java
@@ -1,0 +1,113 @@
+package com.example.easybooking.reservation.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.example.easybooking.reservation.ReservationReader;
+import com.example.easybooking.reservation.ReservationWriter;
+import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.reservation.dto.ReservationOwnerResponse;
+import com.example.easybooking.shop.ShopReader;
+import com.example.easybooking.user.UserReader;
+import com.example.easybooking.user.domain.User;
+import com.example.easybooking.user.domain.UserType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceGetReservationsByCustomerInShopUnitTest {
+
+    @Mock private ReservationWriter reservationWriter;
+    @Mock private ReservationReader reservationReader;
+    @Mock private UserReader userReader;
+    @Mock private ShopReader shopReader;
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private ReservationService reservationService;
+
+    @BeforeEach
+    void setUp() {
+        reservationService = new ReservationService(
+                reservationWriter,
+                reservationReader,
+                userReader,
+                shopReader,
+                objectMapper,
+                eventPublisher
+        );
+    }
+
+    @Test
+    void getReservationsByCustomerInShop_예약0건이면_빈리스트_그리고_고객조회없음() {
+        long ownerId = 1L;
+        long shopId = 2L;
+        long customerId = 3L;
+
+        when(shopReader.isShopOwnedBy(shopId, ownerId)).thenReturn(true);
+        when(reservationReader.findByShopIdAndCustomerId(shopId, customerId)).thenReturn(List.of());
+
+        List<ReservationOwnerResponse> result = reservationService.getReservationsByCustomerInShop(ownerId, shopId, customerId);
+
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(userReader);
+    }
+
+    @Test
+    void getReservationsByCustomerInShop_N건이어도_고객조회1회만() throws Exception {
+        long ownerId = 10L;
+        long shopId = 20L;
+        long customerId = 30L;
+
+        when(shopReader.isShopOwnedBy(shopId, ownerId)).thenReturn(true);
+
+        Map<String, String> formData = Map.of(
+                "part", "손",
+                "removal", "예",
+                "requests", "요청",
+                "extend", "0",
+                "wrapping", "0"
+        );
+        String formJson = objectMapper.writeValueAsString(formData);
+
+        Reservation r1 = Reservation.createReservation(
+                shopId, ownerId, customerId,
+                LocalDate.parse("2026-01-10"), LocalTime.parse("10:00"),
+                formJson, List.of()
+        );
+        Reservation r2 = Reservation.createReservation(
+                shopId, ownerId, customerId,
+                LocalDate.parse("2026-01-11"), LocalTime.parse("11:00"),
+                formJson, List.of()
+        );
+        when(reservationReader.findByShopIdAndCustomerId(shopId, customerId)).thenReturn(List.of(r1, r2));
+
+        when(userReader.read(customerId)).thenReturn(User.createUser("provider-c", "고객", "01000000000", UserType.CUSTOMER));
+
+        List<ReservationOwnerResponse> result = reservationService.getReservationsByCustomerInShop(ownerId, shopId, customerId);
+
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(x -> "고객".equals(x.getCustomerName())));
+
+        verify(userReader, times(1)).read(customerId);
+        verify(userReader, never()).readAllByIds(org.mockito.ArgumentMatchers.anyList());
+        verify(shopReader, times(1)).isShopOwnedBy(shopId, ownerId);
+        verify(reservationReader, times(1)).findByShopIdAndCustomerId(shopId, customerId);
+    }
+}
+

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetShopReservationUnitTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetShopReservationUnitTest.java
@@ -1,0 +1,149 @@
+package com.example.easybooking.reservation.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.example.easybooking.reservation.ReservationReader;
+import com.example.easybooking.reservation.ReservationWriter;
+import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.reservation.dto.ReservationOwnerResponse;
+import com.example.easybooking.shop.ShopReader;
+import com.example.easybooking.user.UserReader;
+import com.example.easybooking.user.domain.User;
+import com.example.easybooking.user.domain.UserType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceGetShopReservationUnitTest {
+
+    @Mock private ReservationWriter reservationWriter;
+    @Mock private ReservationReader reservationReader;
+    @Mock private UserReader userReader;
+    @Mock private ShopReader shopReader;
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private ReservationService reservationService;
+
+    @BeforeEach
+    void setUp() {
+        reservationService = new ReservationService(
+                reservationWriter,
+                reservationReader,
+                userReader,
+                shopReader,
+                objectMapper,
+                eventPublisher
+        );
+    }
+
+    @Test
+    void getShopReservation_샵이없으면_빈리스트() {
+        long ownerId = 1L;
+        when(userReader.read(ownerId)).thenReturn(User.createUser("provider-owner", "원장", "010", UserType.OWNER));
+        when(shopReader.findShopIdsByOwnerId(ownerId)).thenReturn(List.of());
+
+        List<ReservationOwnerResponse> result = reservationService.getShopReservation(ownerId);
+
+        assertTrue(result.isEmpty());
+        verifyNoInteractions(reservationReader);
+    }
+
+    @Test
+    void getShopReservation_N건이어도_고객조회는_IN1회_그리고_고객단건조회는_없음() throws Exception {
+        long ownerId = 10L;
+        when(userReader.read(ownerId)).thenReturn(User.createUser("provider-owner", "원장", "010", UserType.OWNER));
+
+        // owner가 가진 shopIds
+        when(shopReader.findShopIdsByOwnerId(ownerId)).thenReturn(List.of(100L));
+
+        Map<String, String> formData = Map.of(
+                "part", "손",
+                "removal", "예",
+                "requests", "요청",
+                "extend", "0",
+                "wrapping", "0"
+        );
+        String formJson = objectMapper.writeValueAsString(formData);
+
+        long customer1Id = 101L;
+        long customer2Id = 202L;
+
+        Reservation r1 = Reservation.createReservation(
+                100L, ownerId, customer1Id,
+                LocalDate.parse("2026-01-10"), LocalTime.parse("10:00"),
+                formJson, List.of()
+        );
+        Reservation r2 = Reservation.createReservation(
+                100L, ownerId, customer2Id,
+                LocalDate.parse("2026-01-11"), LocalTime.parse("11:00"),
+                formJson, List.of()
+        );
+        Reservation r3 = Reservation.createReservation(
+                100L, ownerId, customer1Id,
+                LocalDate.parse("2026-01-12"), LocalTime.parse("12:00"),
+                formJson, List.of()
+        );
+
+        when(reservationReader.findByShopIdIn(List.of(100L))).thenReturn(List.of(r1, r2, r3));
+
+        // 배치 조회로 반환될 고객들
+        User c1 = User.createUser("provider-c1", "고객1", "01011111111", UserType.CUSTOMER);
+        User c2 = User.createUser("provider-c2", "고객2", "01022222222", UserType.CUSTOMER);
+
+        // createUser는 id를 세팅하지 않으므로, id 매핑은 mock으로 보강
+        // -> 여기서는 서비스가 Map 키로 getId()를 쓰므로 Mockito mock을 사용
+        User c1Mock = org.mockito.Mockito.mock(User.class);
+        when(c1Mock.getId()).thenReturn(customer1Id);
+        when(c1Mock.getName()).thenReturn(c1.getName());
+        when(c1Mock.getPhoneNumber()).thenReturn(c1.getPhoneNumber());
+
+        User c2Mock = org.mockito.Mockito.mock(User.class);
+        when(c2Mock.getId()).thenReturn(customer2Id);
+        when(c2Mock.getName()).thenReturn(c2.getName());
+        when(c2Mock.getPhoneNumber()).thenReturn(c2.getPhoneNumber());
+
+        when(userReader.readAllByIds(anyList())).thenReturn(List.of(c1Mock, c2Mock));
+
+        List<ReservationOwnerResponse> result = reservationService.getShopReservation(ownerId);
+
+        assertEquals(3, result.size());
+        assertEquals(
+                Set.of("고객1", "고객2"),
+                result.stream().map(ReservationOwnerResponse::getCustomerName).collect(Collectors.toSet())
+        );
+
+        // owner 권한 확인용 read 1회
+        verify(userReader, times(1)).read(ownerId);
+        // 고객 배치 조회 1회
+        verify(userReader, times(1)).readAllByIds(anyList());
+        // 고객 단건 조회는 없어야 함 (N+1 회귀 방지)
+        verify(userReader, never()).read(customer1Id);
+        verify(userReader, never()).read(customer2Id);
+        // 과거 구현으로 회귀하면 발생하던 호출들 방지
+        verify(shopReader, times(1)).findShopIdsByOwnerId(ownerId);
+        verify(reservationReader, times(1)).findByShopIdIn(anyList());
+        verify(reservationReader, never()).findByCustomerId(anyLong());
+    }
+}
+


### PR DESCRIPTION
## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

#93 

## 📝 요약(Summary)

## 개요

예약 도메인의 “목록/조회” 흐름에서 발생 가능한 **N+1(user/shop 반복 조회)**을 줄이고, 채팅방 점주용 조회 메서드명을 **의도를 드러내는 이름**으로 변경했습니다.

- **핵심 목표**: 목록 조회에서 반복되는 `read()` 호출을 제거(배치 조회/단일 조회 재사용)
- **변경 성격**: 내부 구현/성능 리팩토링(응답 스펙/엔드포인트 유지)

---

## 변경 범위(한눈에 보기)

| 구분 | 대상 | 이전 문제 | 변경 후 |
|---|---|---|---|
| 고객 | `getMyReservations` | 예약 N건 → shop/user 반복 조회 가능 | customer 1회 + shop IN 1회 |
| 고객(채팅) | `getCustomerReservationInChat` | 전체 조회 후 메모리 필터 + 반복 조회 가능 | DB 필터링 + customer 1회 + shop 1회 |
| 점주 | `getShopReservation` | 예약 N건 → customer(User) N회 조회 가능 | customerIds IN 1회 |
| 점주(채팅) | `getReservationsByCustomerInShop` | 예약 N건 → customer(User) N회 조회 가능 | customer 1회 재사용 |

---

## 변경 상세

### 1) 고객용 “내 예약 목록” N+1 제거 (`getMyReservations`)

#### 배경/문제

`ReservationService#getMyReservations`에서 DTO 변환이 `userReader.read(...)`/`shopReader.read(...)`를 예약 건수만큼 반복 호출할 수 있어 **N+1**이 발생할 수 있었습니다.

#### 변경

- “내 예약” 특성상 고객(User)은 **1번만 조회**
- 예약에서 `shopId` 수집 → `findAllById(IN)`로 샵을 **1번에 조회**
- DTO 변환은 `ReservationCustomerResponse.from(r, customerName, shopName, formData)` 형태로 **순수 변환**에 가깝게 정리

#### 기대 효과(정량)

- 변경 전(최악): \(1 + N + N\)
- 변경 후: 약 **3**(예약 1 + 유저 1 + 샵 IN 1)

> 참고: `Reservation.designImageURLs(@ElementCollection)` 접근은 설정에 따라 별도 N+1이 발생할 수 있어, 추후 “목록 응답에서 photoUrls 제외/배치 로딩 설정” 같은 후속 정리가 필요합니다.

---

### 2) 고객(채팅) 조회: DB 필터링 + 반복 조회 제거 (`getCustomerReservationInChat`)

- 변경 전: `findByCustomerId()`로 전체 로딩 → 메모리에서 `shopId` 필터링
- 변경 후: `customerId + shopId` 조건으로 **DB에서 바로 조회** + customer 1회 + shop 1회

---

### 3) 점주 목록 N+1 제거 (`getShopReservation`)

- 변경 전: `ReservationOwnerResponse.from(..., userReader, ...)` 내부에서 customer 조회가 예약 건수만큼 발생 가능
- 변경 후: `customerIds` 수집 → `UserReader.readAllByIds(IN)`로 **1회 배치 조회** 후 `Map`으로 DTO 변환

---

### 4) 점주(채팅) 조회 메서드명 개선 + 반복 조회 제거

#### 네이밍 변경

- 변경 전: `getOwnerReservationsForCustomer(ownerUserId, shopId, customerId)`
- 변경 후: `getReservationsByCustomerInShop(ownerUserId, shopId, customerId)`

변경 이유: `forCustomer`는 “고객을 위해(대신)”처럼 읽힐 수 있어, 실제 의미(“shop 스코프에서 customerId로 필터링”)가 약했습니다.

#### 성능 변경

- `customerId`가 단일이므로 `userReader.read(customerId)`를 **1회만** 수행하고 변환에 재사용

---

## DTO/매핑 정리

- `ReservationOwnerResponse`:
  - `from(reservation, customerName, customerPhone, formData)` 오버로드 추가
  - 기존 `from(reservation, userReader, formData)`는 유지하되 내부에서 오버로드로 위임(점진적 전환)
- `ReservationCustomerResponse`:
  - `from(reservation, customerName, shopName, formData)` 오버로드 사용

---

## 영향 범위

- API 스펙 변경 없음(엔드포인트/응답 DTO 구조 동일)
- 메서드명 변경은 컴파일 타임에 호출부 누락이 발견되도록 안전하게 리팩토링됨

---

## 테스트

- 단위 테스트 추가(실행은 CI/로컬에서 수행):
  - `ReservationServiceGetShopReservationUnitTest`
  - `ReservationServiceGetReservationsByCustomerInShopUnitTest`

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced N+1 lookups by batching customer and shop reads, reusing precomputed names/photos, and returning early for empty results.

* **New Features**
  * Owner-facing view to fetch a specific customer’s reservations within a shop (same request/response behavior).

* **Tests**
  * Added unit tests covering empty-result cases and verifying batched customer/shop lookups (no per-reservation extra reads).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->