### PR TITLE
refactor : 예약 ERD v2 반영(Flyway 도입 + V1~V3 마이그레이션 추가)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,12 @@
 spring:
   application:
     name: snapbook
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+    baseline-version: 0
+    clean-disabled: true
   servlet:
     multipart:
       max-file-size: 10MB
@@ -56,19 +62,21 @@ spring:
   application:
     name: snapbook
   datasource:
-    url: jdbc:h2:file:./data/testdb
-    driverClassName: org.h2.Driver
-    username: sa
-    password:
-  h2:
-    console:
-      enabled: true
+    url: jdbc:mysql://localhost:3307/local_snapbook?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: snapbook
+    password: snapbookpw
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 50
+
   jpa:
     hibernate:
+      # Flyway 전환 초기에는 update를 유지(기존 코드 호환).
+      # 예약/메뉴/점유 도메인 리팩토링이 끝나면 validate로 전환 권장.
       ddl-auto: update
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.MySQLDialect
   kakao:
     auth:
       client: ${KAKAO_CLIENT_ID}
@@ -86,6 +94,7 @@ logging:
   level:
     root: WARN
     com.example.easybooking: INFO
+    org.hibernate.SQL: DEBUG
 ---
 
 spring:

--- a/src/main/resources/db/migration/V1__reservation_v2_phase1_add_tables_and_columns.sql
+++ b/src/main/resources/db/migration/V1__reservation_v2_phase1_add_tables_and_columns.sql
@@ -1,0 +1,150 @@
+-- 예약 ERD v2 Phase 1: 파괴적 변경 없이 "추가만"
+-- Created: 2026-01-23
+
+-- 1) reservations 확장 컬럼 (초기에는 NULL 허용)
+ALTER TABLE reservations
+  ADD COLUMN staff_id BIGINT NULL,
+  ADD COLUMN start_at DATETIME NULL,
+  ADD COLUMN duration_minutes INT NULL,
+  ADD COLUMN customer_note TEXT NULL,
+  ADD COLUMN updated_at DATETIME NULL,
+  ADD COLUMN deleted_at DATETIME NULL;
+
+-- 2) staff (복수 직원 지원)
+CREATE TABLE staff (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  shop_id BIGINT NOT NULL,
+  user_id BIGINT NULL,
+  name VARCHAR(100) NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  INDEX idx_staff_shop_id (shop_id),
+  INDEX idx_staff_user_id (user_id)
+);
+
+-- 3) reservation_time_blocks (CONFIRMED 점유 블록)
+CREATE TABLE reservation_time_blocks (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  reservation_id BIGINT NOT NULL,
+  staff_id BIGINT NOT NULL,
+  block_start_at DATETIME NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  INDEX idx_rtb_reservation_id (reservation_id),
+  INDEX idx_rtb_staff_block_start_at (staff_id, block_start_at)
+);
+
+-- 4) shop_services (매장별 메뉴)
+CREATE TABLE shop_services (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  shop_id BIGINT NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  description TEXT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  sort_order INT NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  deleted_at DATETIME NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_shop_services_shop_name (shop_id, name),
+  INDEX idx_shop_services_shop_active_sort (shop_id, is_active, sort_order)
+);
+
+-- 5) tags + shop_service_tags (메뉴 태그)
+CREATE TABLE tags (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  name VARCHAR(100) NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_tags_name (name)
+);
+
+CREATE TABLE shop_service_tags (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  shop_service_id BIGINT NOT NULL,
+  tag_id BIGINT NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_shop_service_tags (shop_service_id, tag_id),
+  INDEX idx_shop_service_tags_tag (tag_id, shop_service_id)
+);
+
+-- 6) shop_service_input_fields (메뉴별 추가 입력 필드)
+CREATE TABLE shop_service_input_fields (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  shop_service_id BIGINT NOT NULL,
+  `key` VARCHAR(100) NOT NULL,
+  label VARCHAR(255) NOT NULL,
+  input_type VARCHAR(20) NOT NULL, -- NUMBER | TEXT
+  required BOOLEAN NOT NULL DEFAULT FALSE,
+  min_value DECIMAL(10,2) NULL,
+  max_value DECIMAL(10,2) NULL,
+  step_value DECIMAL(10,2) NULL,
+  max_length INT NULL,
+  placeholder VARCHAR(255) NULL,
+  sort_order INT NOT NULL DEFAULT 0,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_shop_service_input_fields (shop_service_id, `key`),
+  INDEX idx_shop_service_input_fields_service (shop_service_id, is_active, sort_order)
+);
+
+-- 7) reservation_services (예약-메뉴 다중 선택 + 스냅샷)
+CREATE TABLE reservation_services (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  reservation_id BIGINT NOT NULL,
+  shop_service_id BIGINT NOT NULL,
+  service_name_snapshot VARCHAR(255) NOT NULL,
+  service_description_snapshot TEXT NULL,
+  service_duration_snapshot_minutes INT NULL,
+  sort_order INT NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  INDEX idx_reservation_services_reservation (reservation_id, sort_order),
+  INDEX idx_reservation_services_shop_service (shop_service_id)
+);
+
+-- 8) reservation_menu_input_values (예약-메뉴별 추가 입력값 + 스냅샷)
+CREATE TABLE reservation_menu_input_values (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  reservation_service_id BIGINT NOT NULL,
+  shop_service_input_field_id BIGINT NOT NULL,
+  field_key_snapshot VARCHAR(100) NOT NULL,
+  field_label_snapshot VARCHAR(255) NOT NULL,
+  input_type_snapshot VARCHAR(20) NOT NULL, -- NUMBER | TEXT
+  value_number DECIMAL(10,2) NULL,
+  value_text TEXT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  INDEX idx_res_menu_input_values_res_service (reservation_service_id)
+);
+
+-- 9) 이력 테이블(상태/변경)
+CREATE TABLE reservation_status_histories (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  reservation_id BIGINT NOT NULL,
+  from_status VARCHAR(20) NULL,
+  to_status VARCHAR(20) NOT NULL,
+  changed_by_user_id BIGINT NOT NULL,
+  reason TEXT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  INDEX idx_rsh_reservation (reservation_id, created_at)
+);
+
+CREATE TABLE reservation_change_histories (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  reservation_id BIGINT NOT NULL,
+  changed_by_user_id BIGINT NOT NULL,
+  change_type VARCHAR(50) NOT NULL,
+  before_json LONGTEXT NULL,
+  after_json LONGTEXT NULL,
+  reason TEXT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  INDEX idx_rch_reservation (reservation_id, created_at)
+);
+

--- a/src/main/resources/db/migration/V2__reservation_v2_phase2_backfill_start_at_and_staff.sql
+++ b/src/main/resources/db/migration/V2__reservation_v2_phase2_backfill_start_at_and_staff.sql
@@ -1,0 +1,32 @@
+-- 예약 ERD v2 Phase 2: backfill (start_at, staff)
+-- Created: 2026-01-23
+
+-- 1) date + time -> start_at
+UPDATE reservations
+SET start_at = TIMESTAMP(`date`, `time`)
+WHERE start_at IS NULL
+  AND `date` IS NOT NULL
+  AND `time` IS NOT NULL;
+
+-- 2) 기본 staff 생성 (기존 예약 기준: shop_id + owner_user_id 조합)
+-- 주의: 이미 staff가 있을 수 있으므로 중복 삽입 방지를 위해 NOT EXISTS 사용
+INSERT INTO staff (shop_id, user_id, name, created_at, updated_at)
+SELECT r.shop_id, r.owner_user_id, NULL, NOW(), NOW()
+FROM reservations r
+WHERE r.shop_id IS NOT NULL
+  AND r.owner_user_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM staff s
+    WHERE s.shop_id = r.shop_id AND s.user_id = r.owner_user_id
+  )
+GROUP BY r.shop_id, r.owner_user_id;
+
+-- 3) reservations.staff_id 채우기
+UPDATE reservations r
+JOIN staff s
+  ON s.shop_id = r.shop_id
+ AND s.user_id = r.owner_user_id
+SET r.staff_id = s.id
+WHERE r.staff_id IS NULL;
+

--- a/src/main/resources/db/migration/V3__reservation_v2_phase3_constraints_and_indexes.sql
+++ b/src/main/resources/db/migration/V3__reservation_v2_phase3_constraints_and_indexes.sql
@@ -1,0 +1,41 @@
+-- 예약 ERD v2 Phase 3: 제약/인덱스 적용
+-- Created: 2026-01-23
+
+-- 1) 점유 겹침 방지(확정 시점)
+ALTER TABLE reservation_time_blocks
+  ADD CONSTRAINT uq_rtb_staff_block_start_at UNIQUE (staff_id, block_start_at);
+
+-- 2) 동일 메뉴 중복 선택 금지(확정)
+ALTER TABLE reservation_services
+  ADD CONSTRAINT uq_reservation_services_res_shop_service UNIQUE (reservation_id, shop_service_id);
+
+-- 3) 메뉴별 입력값: 동일 필드 중복 입력 방지
+ALTER TABLE reservation_menu_input_values
+  ADD CONSTRAINT uq_res_menu_input_values UNIQUE (reservation_service_id, shop_service_input_field_id);
+
+-- 4) 조회 성능 인덱스(권장)
+CREATE INDEX idx_res_shop_status_start_at ON reservations (shop_id, status, start_at);
+CREATE INDEX idx_res_staff_start_at ON reservations (staff_id, start_at);
+CREATE INDEX idx_res_customer_created_at ON reservations (customer_id, created_at);
+
+-- 5) 내부 FK(신규 테이블끼리) — 기존 테이블(shop/users 등)로의 FK는 스키마 확인 후 추가하는 것을 권장
+ALTER TABLE reservation_time_blocks
+  ADD CONSTRAINT fk_rtb_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id);
+ALTER TABLE reservation_time_blocks
+  ADD CONSTRAINT fk_rtb_staff FOREIGN KEY (staff_id) REFERENCES staff(id);
+
+ALTER TABLE reservation_services
+  ADD CONSTRAINT fk_res_services_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id);
+ALTER TABLE reservation_services
+  ADD CONSTRAINT fk_res_services_shop_service FOREIGN KEY (shop_service_id) REFERENCES shop_services(id);
+
+ALTER TABLE reservation_menu_input_values
+  ADD CONSTRAINT fk_rmiv_res_service FOREIGN KEY (reservation_service_id) REFERENCES reservation_services(id);
+ALTER TABLE reservation_menu_input_values
+  ADD CONSTRAINT fk_rmiv_input_field FOREIGN KEY (shop_service_input_field_id) REFERENCES shop_service_input_fields(id);
+
+ALTER TABLE shop_service_tags
+  ADD CONSTRAINT fk_sst_shop_service FOREIGN KEY (shop_service_id) REFERENCES shop_services(id);
+ALTER TABLE shop_service_tags
+  ADD CONSTRAINT fk_sst_tag FOREIGN KEY (tag_id) REFERENCES tags(id);
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: easybooking-test
+  flyway:
+    enabled: false
   datasource:
     url: jdbc:h2:mem:testdb
     driverClassName: org.h2.Driver


### PR DESCRIPTION
# PR - 예약 ERD v2 반영(Flyway 도입 + V1~V3 마이그레이션 추가)

Created: 2026-01-25
Issue: [WAP-SNAPBOOK/BE#95](https://github.com/WAP-SNAPBOOK/BE/issues/95)
Branch: `feature/jiseob/#95-reservation-erd-v2-flyway`

## 개요

예약 도메인 ERD v2 적용을 위해, **Flyway를 도입**하고 **예약 ERD v2용 DB 마이그레이션(V1~V3)** 을 추가.

---

## 변경 범위

| 구분 | 대상 | 변경 내용 |
|---|---|---|
| 의존성 | `build.gradle` | Flyway 의존성 추가(`flyway-core`, `flyway-mysql`) |
| 설정 | `application.yml` | Flyway 활성화 + local DB를 MySQL로 전환(승인됨) |
| 설정(테스트) | `src/test/resources/application.yml` | 테스트에서 Flyway 비활성화 |
| DB | `db/migration/V1~V3` | 예약 ERD v2 스키마 추가/백필/제약 적용 |

---

## 변경 상세

### 1) Flyway 도입/활성화

- `build.gradle`
  - `org.flywaydb:flyway-core`
  - `org.flywaydb:flyway-mysql`
- `src/main/resources/application.yml`
  - `spring.flyway.enabled=true`
  - `locations=classpath:db/migration`
  - `baseline-on-migrate=true`, `baseline-version=0`
  - `clean-disabled=true`
- `src/test/resources/application.yml`
  - 테스트에서는 Flyway를 끔(`spring.flyway.enabled=false`)

---

### 2) 예약 ERD v2 마이그레이션 추가(V1~V3)

#### V1 — 데이터 확장

- `reservations` 테이블 확장(초기 NULL 허용)
  - `staff_id`, `start_at`, `duration_minutes`, `customer_note`, `updated_at`, `deleted_at`
- 신규 테이블 추가(ERD v2의 핵심 구성요소)
  - `staff`
  - 점유(겹침 방지): `reservation_time_blocks`
  - 매장별 메뉴: `shop_services`
  - 태그 필터: `tags`, `shop_service_tags`
  - 메뉴별 입력 정의: `shop_service_input_fields`
  - 예약-메뉴 선택/스냅샷: `reservation_services`
  - 예약-메뉴 입력값/스냅샷: `reservation_menu_input_values`
  - 이력: `reservation_status_histories`, `reservation_change_histories`

#### V2 — backfill

- `start_at = TIMESTAMP(date, time)` 채우기
- 기존 예약의 `(shop_id, owner_user_id)` 기준으로 기본 `staff` 생성
- `reservations.staff_id` backfill

#### V3 — 제약/인덱스/FK

- 겹침 방지(확정 점유): `reservation_time_blocks`에 `UNIQUE(staff_id, block_start_at)`
- 예약-메뉴 중복 선택 방지: `reservation_services`에 `UNIQUE(reservation_id, shop_service_id)`
- 메뉴 입력값 중복 방지: `reservation_menu_input_values`에 `UNIQUE(reservation_service_id, shop_service_input_field_id)`
- 조회 인덱스 추가: `reservations`의 `shop/status/start_at`, `staff/start_at`, `customer/created_at`
- 신규 테이블끼리 FK 추가(기존 도메인 테이블로의 FK는 추후 스키마 확인 후 단계적으로)

---

## 영향 범위

- 기존 예약 기능은 그대로 동작(기존 컬럼/로직 유지)
- 신규 스키마/마이그레이션이 추가되어, 이후 단계에서 ERD v2 기반으로 코드 전환 가능

---

## 테스트

- [x] local(MySQL)에서 앱 기동 시 Flyway가 실행되고 `flyway_schema_history`에 V1~V3 성공 기록이 남는지 확인
- [x] 신규 테이블/컬럼 생성 여부 확인
- [x] 테스트 실행(테스트에서는 Flyway 비활성화)

---

## 리스크/운영 메모

- `baseline-on-migrate`는 “첫 도입” 편의 옵션이라, 안정 적용 후에는 재검토 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database migration framework for managing schema changes.
  * Migrated database backend from H2 to MySQL with connection pooling.
  * Expanded reservation data model to support staff assignment, time blocks, shop-specific services, tags, dynamic input fields, and comprehensive change history tracking.

* **Chores**
  * Added Flyway dependencies to build configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->