### PR TITLE
feat : 메뉴 다중 선택, 추가 입력, 태그 필터링 기능 구현

### DIFF
--- a/docs/issues/#99/01-issue/0001-github-issue-draft.md
+++ b/docs/issues/#99/01-issue/0001-github-issue-draft.md
@@ -1,0 +1,72 @@
+# 예약 메뉴 다중 선택 / 추가 입력 / 태그 필터링
+
+Issue: `#99`  
+Created: 2026-02-10
+
+---
+
+## 배경
+
+#97에서 예약 ERD v2 핵심(시간축 전환, 점유 블록)을 구현했으나, 메뉴/입력값/태그 관련 기능은 Non-goals로 분리됨. 현재 예약 데이터는 `formDataJson`(비정형 JSON)에 전적으로 의존하고 있어 구조화된 메뉴 관리가 불가능한 상태.
+
+## Goals
+
+- 매장별 메뉴(ShopMenu) CRUD API
+- 태그(Tag) 기반 메뉴 필터링 API
+- 메뉴별 추가 입력 필드(ShopMenuInputField) CRUD API
+- 예약 생성 시 메뉴 다중 선택 + 입력값 저장 (dual-write)
+- 예약 조회 시 메뉴/입력값 포함 응답
+
+## Non-goals
+
+- `formDataJson` 완전 제거 (별도 이슈)
+- 메뉴별 가격/이미지 관리
+
+## 요구사항
+
+### 기능
+
+- 점주가 메뉴를 생성/수정/비활성화할 수 있다
+- 메뉴에 태그를 붙이고, 태그로 필터링할 수 있다
+- 메뉴별 추가 입력 필드(NUMBER/TEXT)를 정의할 수 있다
+- 고객이 예약 시 메뉴를 여러 개 선택하고, 입력값을 제출할 수 있다
+- 예약 조회 시 선택된 메뉴 + 입력값이 응답에 포함된다
+
+### 비기능
+
+- 기존 `formDataJson` 호환 유지 (dual-write)
+- 메뉴 삭제 시 soft delete + 스냅샷으로 예약 데이터 보존
+
+## 수용 기준 (AC)
+
+- AC-1: `POST /api/shops/{shopId}/menus`로 메뉴 생성, `GET`으로 활성 메뉴 목록 조회
+- AC-2: `GET /api/shops/{shopId}/menus?tagIds=1,2`로 태그 필터링 동작
+- AC-3: 메뉴별 입력 필드 CRUD 동작
+- AC-4: 예약 생성 API가 `menuIds` + 메뉴별 입력값을 구조화된 형태로 수신하고, `reservation_menu_items` / `reservation_menu_input_values`에 저장한다
+- AC-5: 예약 생성 시 기존 `formDataJson`도 함께 저장된다 (dual-write, 레거시 호환)
+- AC-6: 예약 조회 응답에 메뉴/입력값 포함 (없으면 `formDataJson` fallback)
+
+## 범위/의존성
+
+- DB 테이블: V1~V3에서 생성, V4에서 `shop_menus` 계열로 리네이밍 + `key` 컬럼 제거
+- 의존: #97 (예약 ERD v2 핵심 구현 완료 전제)
+
+## 리스크
+
+- `formDataJson` 의존 코드 산재 → dual-write로 완화
+- 기존 예약에 `reservation_menu_items` 없음 → 조회 시 fallback 처리
+
+## 작업 체크리스트
+
+- [ ] V4 마이그레이션 적용 (리네이밍 + key 제거)
+- [ ] ShopMenu 엔티티 + CRUD API (Phase 1)
+- [ ] Tag + 태그 필터링 API (Phase 2)
+- [ ] ShopMenuInputField + CRUD API (Phase 3)
+- [ ] 예약-메뉴 선택 + 입력값 저장 (Phase 4)
+- [ ] 예약 조회 응답 확장 (Phase 5)
+
+## 관련 문서
+
+- 설계안: `docs/issues/#99/02-design/design-plan.md`
+- TDD plan: `docs/issues/#99/04-tdd/plan.md`
+- ERD v2: `docs/issues/#97/reservation-erd-v2.md`

--- a/docs/issues/#99/02-design/design-plan.md
+++ b/docs/issues/#99/02-design/design-plan.md
@@ -1,0 +1,255 @@
+# #99 메뉴 다중 선택 / 추가 입력 / 태그 필터링 — Design Plan
+
+Created: 2026-02-10  
+Issue: `#99`  
+Parent ERD: `docs/issues/#97/reservation-erd-v2.md` (라인 7-9)  
+Branch: `develop`
+
+---
+
+## 1. 배경 / 문제
+
+### ERD v2 요구사항 (라인 7-9)
+
+- 시작 시간(`start_at`)과 점유 블록(`block_start_at`)은 **모두 10분 단위**다.
+- 예약은 **메뉴를 여러 개 선택 가능**, 메뉴별로 **추가 입력(NUMBER/TEXT)** 이 붙을 수 있다.
+- 메뉴는 **태그로 필터링** 가능해야 한다.
+
+### 현황
+
+| 항목 | 상태 |
+|------|------|
+| DB 테이블 | Flyway V1~V3으로 6개 테이블 존재 → V4에서 `shop_menus`, `shop_menu_tags`, `shop_menu_input_fields`, `reservation_menu_items`, `reservation_menu_input_values` 로 리네이밍 |
+| Java 엔티티 | 해당 테이블 매핑 엔티티 **없음** |
+| 예약 흐름 | `formDataJson`(비정형 JSON)에 전적 의존 |
+| #97 plan.md | 이 기능들은 "Non-goals(후속 이슈)"로 명시됨 |
+
+### 구현 대상 엔티티 (6개)
+
+```
+shop_menus                    → ShopMenu              (매장별 메뉴)
+tags                          → Tag                   (태그)
+shop_menu_tags                → ShopMenuTag            (메뉴-태그 연결)
+shop_menu_input_fields        → ShopMenuInputField     (메뉴별 추가 입력 정의)
+reservation_menu_items        → ReservationMenuItem    (예약-메뉴 다중 선택 + 스냅샷)
+reservation_menu_input_values → ReservationMenuInputValue (예약-메뉴별 입력값 + 스냅샷)
+```
+
+---
+
+## 2. 설계안 비교
+
+### 설계안 A: Vertical Slice (기능 단위 수직 관통) — 추천
+
+각 기능을 엔티티 - Repository - Reader/Writer - Service - Controller까지 수직으로 관통하며 구현.
+
+```
+Phase 1: ShopMenu(메뉴) CRUD — 엔티티 ~ API
+Phase 2: Tag + 태그 기반 메뉴 필터링 — 엔티티 ~ API
+Phase 3: ShopMenuInputField(메뉴별 추가 입력 필드) CRUD — 엔티티 ~ API
+Phase 4: 예약 생성 시 메뉴 선택 + 입력값 저장 — 엔티티 ~ 서비스
+Phase 5: 예약 조회 시 메뉴/입력값 포함 응답 — 서비스 ~ API
+```
+
+| 장점 | 단점 |
+|------|------|
+| 각 Phase 완료 시 동작하는 기능 산출 | 초기에 공통 구조가 안 잡히면 리팩토링 비용 발생 가능 |
+| 프론트엔드와 병렬 작업 가능 | |
+| TDD Red-Green-Refactor와 잘 맞음 | |
+| 빠른 피드백 루프 | |
+
+### 설계안 B: Layered (계층별 일괄 구축)
+
+엔티티 6개 전체 → Reader/Writer 전체 → Service 전체 → API 전체 순서로 구축.
+
+| 장점 | 단점 |
+|------|------|
+| 구조 일관성, 공통 패턴 한 번에 확립 | API까지 오래 걸림 |
+| | Phase별 동작하는 기능 없음 |
+| | TDD 사이클이 길어짐 |
+
+### 결정: 설계안 A (Vertical Slice)
+
+**근거**: TDD 사이클에 적합하고, 각 Phase 완료 시 프론트엔드와 병렬 작업이 가능함. 리팩토링 비용은 Phase 간 Refactor 단계에서 흡수.
+
+---
+
+## 3. 단계별 롤아웃 (ADD → Dual-write → Switch → Cleanup)
+
+### 3.1 ADD (이번 이슈 범위)
+
+- 엔티티 클래스 + Repository + Reader/Writer + Service + Controller 추가
+- DB 테이블은 V4 리네이밍 후 존재
+- 메뉴 CRUD API, 태그 필터링 API, 입력 필드 CRUD API 제공
+
+### 3.2 Dual-write (이번 이슈 범위)
+
+- 예약 생성 시 기존 `formDataJson` **+ 신규 `reservation_menu_items`/`reservation_menu_input_values`** 동시 저장
+- 기존 응답 포맷(`formDataJson` 기반) 유지
+- 신규 응답 필드(`menus` 배열)를 별도로 추가
+
+### 3.3 Switch (후속 이슈)
+
+- 응답에서 `reservation_menu_items` 기반 데이터를 우선 사용
+- `formDataJson`은 fallback으로만 유지
+
+### 3.4 Cleanup (별도 이슈)
+
+- `formDataJson` 의존 완전 제거
+- `Reservation.formDataJson` 컬럼 nullable 전환 → 최종 삭제
+
+---
+
+## 4. 패키지 구조
+
+기존 프로젝트 패턴(도메인별 패키지)을 따름.
+
+```
+com.example.easybooking.shop.domain/
+  ShopMenu.java
+  Tag.java
+  ShopMenuTag.java
+  ShopMenuInputField.java
+
+com.example.easybooking.shop.repository/
+  ShopMenuRepository.java
+  TagRepository.java
+  ShopMenuTagRepository.java
+  ShopMenuInputFieldRepository.java
+
+com.example.easybooking.shop/
+  ShopMenuReader.java
+  ShopMenuWriter.java
+  TagReader.java
+  TagWriter.java
+  ShopMenuInputFieldReader.java
+  ShopMenuInputFieldWriter.java
+
+com.example.easybooking.shop.service/
+  ShopMenuManagementService.java  (메뉴 CRUD 비즈니스 로직)
+  TagService.java                 (태그 관리)
+
+com.example.easybooking.shop.presentation/
+  ShopMenuController.java         (메뉴 + 태그 + 입력 필드 API)
+
+com.example.easybooking.shop.dto/
+  (요청/응답 DTO)
+
+com.example.easybooking.reservation.domain/
+  ReservationMenuItem.java
+  ReservationMenuInputValue.java
+
+com.example.easybooking.reservation.repository/
+  ReservationMenuItemRepository.java
+  ReservationMenuInputValueRepository.java
+
+com.example.easybooking.reservation/
+  ReservationMenuItemReader.java
+  ReservationMenuItemWriter.java
+  ReservationMenuInputValueReader.java
+  ReservationMenuInputValueWriter.java
+```
+
+---
+
+## 5. 리스크 및 롤백 전략
+
+### 리스크 1: `formDataJson` 의존 코드 산재
+
+- **영향**: 프론트엔드 + 기존 API 응답이 `formDataJson`에 의존
+- **완화**: Dual-write 단계에서 기존 응답 포맷 유지. `reservation_menu_items` 데이터는 **별도 필드**로 추가
+- **롤백**: `reservation_menu_items` 저장 로직만 제거 → 기존 동작 복원
+
+### 리스크 2: 태그 동시 생성 시 UNIQUE 충돌
+
+- **영향**: 같은 이름의 태그를 동시에 생성하면 `UNIQUE(name)` 위반
+- **완화**: `findByName()` → 없으면 `save()` 패턴 + `DataIntegrityViolationException` 시 retry
+- **롤백**: 해당 없음 (데이터 정합성 문제없음)
+
+### 리스크 3: 기존 예약에 `reservation_menu_items` 없음
+
+- **영향**: 기존 예약 조회 시 메뉴 데이터 빈 상태
+- **완화**: 조회 시 `reservation_menu_items` 비어있으면 `formDataJson` fallback
+- **롤백**: fallback 분기 제거
+
+### 리스크 4: `ShopMenu` 삭제 시 예약 참조 무결성
+
+- **영향**: 삭제된 메뉴가 포함된 기존 예약 조회 불가
+- **완화**: soft delete(`is_active=false`) + 스냅샷(`reservation_menu_items`에 이름/설명 복사)
+- **롤백**: 해당 없음 (스냅샷이 원본과 독립)
+
+---
+
+## 6. 테스트 전략 (엣지 케이스 포함)
+
+> 상세 TDD 테스트 리스트는 `docs/issues/#99/04-tdd/plan.md`에 SSOT로 관리.
+
+### Phase 1: ShopMenu (메뉴) CRUD
+
+| 구분 | 테스트 시나리오 | 엣지 케이스 |
+|------|----------------|------------|
+| 엔티티 매핑 | ShopMenu가 shop_menus에 매핑 | - |
+| 저장 | save 후 ID 할당 | 같은 shop에 동일 이름 → UNIQUE 위반 |
+| 저장 검증 | shopId, name 필수 | null/빈 문자열 → 예외 |
+| 조회 | findByShopId → 활성 메뉴만, sort_order 순 | 메뉴 없으면 빈 리스트 |
+| 조회 | findById → 메뉴 반환 | 없으면 예외 |
+| API | POST 메뉴 생성 | 인증 없음 → 401, 다른 shop → 403 |
+| API | GET 메뉴 목록 | 비활성 메뉴 제외 |
+| API | PATCH 메뉴 수정 | 이름 중복 → 409 |
+| API | DELETE 메뉴 비활성화 | 이미 비활성 → 멱등 |
+
+### Phase 2: Tag + 태그 기반 메뉴 필터링
+
+| 구분 | 테스트 시나리오 | 엣지 케이스 |
+|------|----------------|------------|
+| 엔티티 매핑 | Tag가 tags에 매핑 | - |
+| 저장 | 동일 이름 태그 UNIQUE | idempotent 처리 또는 예외 |
+| 연결 | ShopMenuTag 메뉴-태그 연결 | 중복 연결 → UNIQUE 위반 |
+| 필터링 | tagIds=1 → 해당 태그 메뉴 | 존재하지 않는 tagId → 빈 결과 |
+| 필터링 | tagIds=1,2 → OR 필터 | 태그 없는 메뉴 → 필터 시 제외 |
+| 필터링 | tagIds 미지정 → 전체 활성 메뉴 | 비활성 메뉴 → 무조건 제외 |
+
+### Phase 3: ShopMenuInputField (메뉴별 추가 입력 필드)
+
+| 구분 | 테스트 시나리오 | 엣지 케이스 |
+|------|----------------|------------|
+| 엔티티 매핑 | InputField가 shop_menu_input_fields에 매핑 | - |
+| 저장 | 같은 메뉴에 동일 label → UNIQUE 위반 | - |
+| 타입 검증 | input_type = NUMBER 또는 TEXT만 허용 | 그 외 값 → 예외 |
+| NUMBER 검증 | min_value > max_value → 실패 | step_value <= 0 → 실패 |
+| TEXT 검증 | max_length <= 0 → 실패 | TEXT에 min/max/step 설정 → 무시 |
+| 교차 검증 | NUMBER에 max_length 설정 → 무시 | - |
+| CRUD | 활성 필드만 sort_order 순 조회 | 비활성 필드 제외 |
+
+### Phase 4: 예약 생성 시 메뉴 선택 + 입력값 저장
+
+| 구분 | 테스트 시나리오 | 엣지 케이스 |
+|------|----------------|------------|
+| 메뉴 저장 | 선택한 메뉴가 reservation_menu_items에 저장 | 메뉴 0개 → 예외 (최소 1개) |
+| 스냅샷 | 메뉴 이름/설명이 스냅샷으로 저장 | 원본 변경 후 조회 → 스냅샷 유지 |
+| 중복 | 동일 메뉴 중복 선택 → UNIQUE 위반 | - |
+| 권한 | 다른 shop 메뉴 선택 → 예외 | - |
+| 활성 | 비활성 메뉴 선택 → 예외 | - |
+| 입력값 | required 필드 누락 → 실패 | - |
+| 입력값 | NUMBER 범위 초과 → 실패 | step 미준수 → 실패 |
+| 입력값 | TEXT max_length 초과 → 실패 | - |
+| 입력값 | 타입 불일치 (NUMBER에 text) → 예외 | - |
+| 입력값 | 미정의 field_id에 값 → 예외 | - |
+| Dual-write | formDataJson도 함께 저장 | reservation_menu_items 실패 → 롤백 |
+
+### Phase 5: 예약 조회 시 메뉴/입력값 응답
+
+| 구분 | 테스트 시나리오 | 엣지 케이스 |
+|------|----------------|------------|
+| 조회 | 예약 상세에 메뉴 + 입력값 포함 | reservation_menu_items 비면 formDataJson fallback |
+| 중첩 | 메뉴별 입력값이 하위로 중첩 | 입력값 없는 메뉴 → 빈 배열 |
+
+---
+
+## 7. 관련 문서
+
+- ERD v2 설계: `docs/issues/#97/reservation-erd-v2.md`
+- Flyway V1: `src/main/resources/db/migration/V1__reservation_v2_phase1_add_tables_and_columns.sql`
+- Flyway V3: `src/main/resources/db/migration/V3__reservation_v2_phase3_constraints_and_indexes.sql`
+- Flyway V4 (리네이밍 + key 제거): `src/main/resources/db/migration/V4__rename_shop_services_to_shop_menus.sql`
+- TDD plan (SSOT): `docs/issues/#99/04-tdd/plan.md`

--- a/docs/issues/#99/04-tdd/plan.md
+++ b/docs/issues/#99/04-tdd/plan.md
@@ -418,17 +418,17 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 ### Phase 5-A: 예약 조회 시 메뉴/입력값 응답
 
-- [ ] **5-A-1**: 예약 상세 조회 시 선택된 메뉴 목록 + 입력값이 포함된다
+- [x] **5-A-1**: 예약 상세 조회 시 선택된 메뉴 목록 + 입력값이 포함된다
   - **목적**: 메뉴 정보를 포함한 조회
   - **입력**: 메뉴 2개 + 입력값 포함된 예약 조회
   - **출력**: 응답에 `menus` 배열 (메뉴별 inputValues 중첩 포함)
 
-- [ ] **5-A-2**: `reservation_menu_items` 데이터가 없으면 `formDataJson` fallback
+- [x] **5-A-2**: `reservation_menu_items` 데이터가 없으면 `formDataJson` fallback
   - **목적**: 기존 예약 호환
   - **입력**: reservation_menu_items 없는 기존 예약 조회
   - **출력**: formDataJson 기반 응답 반환
 
-- [ ] **5-A-3**: 메뉴별 입력값이 해당 메뉴 하위로 중첩 반환된다
+- [x] **5-A-3**: 메뉴별 입력값이 해당 메뉴 하위로 중첩 반환된다
   - **목적**: 응답 구조 확인
   - **입력**: 메뉴 A (입력값 2개), 메뉴 B (입력값 0개)
   - **출력**: 메뉴 A -> inputValues[2], 메뉴 B -> inputValues[]
@@ -487,7 +487,7 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 | Phase 4-C | 완료 | 예약-메뉴 선택 로직 |
 | Phase 4-D | 완료 | 예약-입력값 저장 로직 |
 | Phase 4-E | 완료 | Dual-write |
-| Phase 5-A | 대기 | 조회 응답 |
+| Phase 5-A | 완료 | 조회 응답 |
 
 ---
 

--- a/docs/issues/#99/04-tdd/plan.md
+++ b/docs/issues/#99/04-tdd/plan.md
@@ -285,20 +285,20 @@ Design: `docs/issues/#99/02-design/design-plan.md`
   - **엣지케이스**: 이미 비활성 -> 멱등
 
 ---
-
+****
 ### Phase 4-A: ReservationMenuItem 엔티티 + 저장
 
 > **정책**: 예약-메뉴 다중 선택. `UNIQUE(reservation_id, shop_menu_id)`. 메뉴 이름/설명은 스냅샷 저장.
 
-- [ ] **4-A-1**: `ReservationMenuItem` 엔티티가 `reservation_menu_items` 테이블에 매핑된다
+- [x] **4-A-1**: `ReservationMenuItem` 엔티티가 `reservation_menu_items` 테이블에 매핑된다
   - **목적**: DB 매핑 확인
   - **입력**: `ReservationMenuItem(reservationId=1, shopMenuId=1, menuNameSnapshot="젤네일", sortOrder=0)`
   - **출력**: DB에 저장 후 조회 성공
   - **엣지케이스**: reservationId null -> 예외, shopMenuId null -> 예외
 
-- [ ] **4-A-2**: 같은 예약에 동일 메뉴 중복 선택 시 UNIQUE 위반 예외
+- [x] **4-A-2**: 같은 예약에 동일 메뉴 중복 선택 시 UNIQUE 위반 예외
   - **목적**: 메뉴 중복 선택 방지
-  - **입력**: (reservationId=1, shopMenuId=1) 2회 저장
+  - **입력**: (reservationId=1, shopMenuId=1) 2회 **저장**
   - **출력**: `DataIntegrityViolationException`
   - **엣지케이스**: 다른 예약(reservationId=2)에 동일 메뉴 -> 허용
 
@@ -306,12 +306,12 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 ### Phase 4-B: ReservationMenuInputValue 엔티티 + 저장
 
-- [ ] **4-B-1**: `ReservationMenuInputValue` 엔티티가 `reservation_menu_input_values` 테이블에 매핑된다
+- [x] **4-B-1**: `ReservationMenuInputValue` 엔티티가 `reservation_menu_input_values` 테이블에 매핑된다
   - **목적**: DB 매핑 확인
   - **입력**: `ReservationMenuInputValue(reservationMenuItemId=1, shopMenuInputFieldId=1, fieldLabelSnapshot="갯수", inputTypeSnapshot="NUMBER", valueNumber=5)`
   - **출력**: DB에 저장 후 조회 성공
 
-- [ ] **4-B-2**: 동일 (reservationMenuItemId, shopMenuInputFieldId) 중복 시 UNIQUE 위반 예외
+- [x] **4-B-2**: 동일 (reservationMenuItemId, shopMenuInputFieldId) 중복 시 UNIQUE 위반 예외
   - **목적**: 입력값 중복 방지
   - **입력**: 동일 조합 2회 저장
   - **출력**: `DataIntegrityViolationException`
@@ -320,29 +320,29 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 ### Phase 4-C: 예약 생성 시 메뉴 선택 비즈니스 로직
 
-- [ ] **4-C-1**: 예약 생성 시 선택한 메뉴 목록이 `reservation_menu_items`에 저장된다
+- [x] **4-C-1**: 예약 생성 시 선택한 메뉴 목록이 `reservation_menu_items`에 저장된다
   - **목적**: 메뉴 다중 선택 저장
   - **입력**: 예약 생성 요청 + menuIds=[1, 2]
   - **출력**: reservation_menu_items에 2건 저장, 스냅샷(이름/설명) 포함
   - **관측**: reservationId가 올바르게 연결됨
 
-- [ ] **4-C-2**: 메뉴 0개 선택 시 예외가 발생한다
+- [x] **4-C-2**: 메뉴 0개 선택 시 예외가 발생한다
   - **목적**: 최소 1개 메뉴 필수 검증
   - **입력**: menuIds=[] (빈 배열)
   - **출력**: 검증 실패/예외
   - **엣지케이스**: menuIds=null -> 예외
 
-- [ ] **4-C-3**: 다른 shop의 메뉴 선택 시 예외가 발생한다
+- [x] **4-C-3**: 다른 shop의 메뉴 선택 시 예외가 발생한다
   - **목적**: shop 소속 검증
   - **입력**: shopId=1 예약인데 shopId=2의 메뉴 포함
   - **출력**: 예외 (InvalidShopMenuException 또는 유사)
 
-- [ ] **4-C-4**: 비활성(is_active=false) 메뉴 선택 시 예외가 발생한다
+- [x] **4-C-4**: 비활성(is_active=false) 메뉴 선택 시 예외가 발생한다
   - **목적**: 활성 메뉴만 선택 가능
   - **입력**: is_active=false인 메뉴 ID
   - **출력**: 예외
 
-- [ ] **4-C-5**: 메뉴 이름/설명이 스냅샷으로 저장되어 원본 변경과 무관하게 보존된다
+- [x] **4-C-5**: 메뉴 이름/설명이 스냅샷으로 저장되어 원본 변경과 무관하게 보존된다
   - **목적**: 스냅샷 정합성
   - **입력**: 메뉴 "젤네일"로 예약 생성 -> 메뉴 이름을 "젤아트"로 변경
   - **출력**: 예약 조회 시 스냅샷은 "젤네일" 유지
@@ -351,18 +351,18 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 ### Phase 4-D: 예약 생성 시 입력값 저장 비즈니스 로직
 
-- [ ] **4-D-1**: 메뉴별 추가 입력값이 `reservation_menu_input_values`에 저장된다
+- [x] **4-D-1**: 메뉴별 추가 입력값이 `reservation_menu_input_values`에 저장된다
   - **목적**: 입력값 저장 확인
   - **입력**: menuId=1에 대해 `{ fieldId: 1, value: 5 }` (NUMBER 타입)
   - **출력**: reservation_menu_input_values에 저장, 스냅샷(label/type) 포함
   - **관측**: valueNumber=5, valueText=null
 
-- [ ] **4-D-2**: required 필드 값 누락 시 검증 실패
+- [x] **4-D-2**: required 필드 값 누락 시 검증 실패
   - **목적**: 필수 입력 검증
   - **입력**: required=true 필드에 값 미제공
   - **출력**: 검증 실패/예외
 
-- [ ] **4-D-3**: NUMBER 타입에서 min_value~max_value 범위 초과 시 검증 실패
+- [x] **4-D-3**: NUMBER 타입에서 min_value~max_value 범위 초과 시 검증 실패
   - **목적**: 범위 검증
   - **입력**: minValue=1, maxValue=10인 필드에 value=15
   - **출력**: 검증 실패
@@ -371,7 +371,7 @@ Design: `docs/issues/#99/02-design/design-plan.md`
     - value=10 (경계값 상한) -> 허용
     - value=0 (하한 미만) -> 실패
 
-- [ ] **4-D-4**: NUMBER 타입에서 step_value 미준수 시 검증 실패
+- [x] **4-D-4**: NUMBER 타입에서 step_value 미준수 시 검증 실패
   - **목적**: step 검증
   - **입력**: minValue=0, stepValue=5인 필드에 value=3
   - **출력**: 검증 실패
@@ -380,7 +380,7 @@ Design: `docs/issues/#99/02-design/design-plan.md`
     - value=10 -> 허용
     - stepValue=null -> step 검증 건너뜀
 
-- [ ] **4-D-5**: TEXT 타입에서 max_length 초과 시 검증 실패
+- [x] **4-D-5**: TEXT 타입에서 max_length 초과 시 검증 실패
   - **목적**: 길이 검증
   - **입력**: maxLength=100인 필드에 101자 텍스트
   - **출력**: 검증 실패
@@ -388,13 +388,13 @@ Design: `docs/issues/#99/02-design/design-plan.md`
     - 100자 -> 허용 (경계값)
     - maxLength=null -> 검증 건너뜀
 
-- [ ] **4-D-6**: NUMBER 필드에 value_text만 있으면 예외가 발생한다
+- [x] **4-D-6**: NUMBER 필드에 value_text만 있으면 예외가 발생한다
   - **목적**: 타입 매칭 검증
   - **입력**: inputType=NUMBER 필드에 valueText="hello"
   - **출력**: 예외
   - **엣지케이스**: TEXT 필드에 valueNumber만 -> 예외
 
-- [ ] **4-D-7**: 해당 메뉴에 정의되지 않은 input_field_id에 값 입력 시 예외가 발생한다
+- [x] **4-D-7**: 해당 메뉴에 정의되지 않은 input_field_id에 값 입력 시 예외가 발생한다
   - **목적**: 필드 소속 검증
   - **입력**: menuId=1의 메뉴인데 menuId=2에 정의된 fieldId 사용
   - **출력**: 예외
@@ -403,13 +403,13 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 ### Phase 4-E: Dual-write (formDataJson 호환)
 
-- [ ] **4-E-1**: 예약 생성 시 `formDataJson`도 함께 저장된다 (레거시 호환)
+- [x] **4-E-1**: 예약 생성 시 `formDataJson`도 함께 저장된다 (레거시 호환)
   - **목적**: 기존 프론트엔드 호환 유지
   - **입력**: 메뉴 선택 + 입력값 포함 예약 생성
   - **출력**: `reservation.formDataJson`에 레거시 포맷 JSON 저장
   - **관측**: reservation_menu_items + reservation_menu_input_values도 동시 저장
 
-- [ ] **4-E-2**: `reservation_menu_items` 저장 실패 시 전체 트랜잭션이 롤백된다
+- [x] **4-E-2**: `reservation_menu_items` 저장 실패 시 전체 트랜잭션이 롤백된다
   - **목적**: 데이터 정합성 보장
   - **입력**: 유효한 예약 + 잘못된 메뉴 데이터 (UNIQUE 위반 유발)
   - **출력**: 전체 롤백, formDataJson도 저장 안 됨
@@ -482,11 +482,11 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 | Phase 3-A | 대기 | ShopMenuInputField 엔티티 |
 | Phase 3-B | 대기 | ShopMenuInputField 검증 |
 | Phase 3-C | 대기 | ShopMenuInputField CRUD API |
-| Phase 4-A | 대기 | ReservationMenuItem 엔티티 |
-| Phase 4-B | 대기 | ReservationMenuInputValue 엔티티 |
-| Phase 4-C | 대기 | 예약-메뉴 선택 로직 |
-| Phase 4-D | 대기 | 예약-입력값 저장 로직 |
-| Phase 4-E | 대기 | Dual-write |
+| Phase 4-A | 완료 | ReservationMenuItem 엔티티 |
+| Phase 4-B | 완료 | ReservationMenuInputValue 엔티티 |
+| Phase 4-C | 완료 | 예약-메뉴 선택 로직 |
+| Phase 4-D | 완료 | 예약-입력값 저장 로직 |
+| Phase 4-E | 완료 | Dual-write |
 | Phase 5-A | 대기 | 조회 응답 |
 
 ---

--- a/docs/issues/#99/04-tdd/plan.md
+++ b/docs/issues/#99/04-tdd/plan.md
@@ -1,0 +1,501 @@
+# #99 TDD Plan — 메뉴 다중 선택 / 추가 입력 / 태그 필터링
+
+Created: 2026-02-10  
+Issue: `#99`  
+Status: 계획 수립  
+Design: `docs/issues/#99/02-design/design-plan.md`
+
+---
+
+## Ground Rules
+
+1. **Red -> Green -> Refactor**: 실패 테스트 -> 최소 구현 -> 리팩토링
+2. **Tidy First**: 구조 변경과 동작 변경을 같은 커밋에 섞지 않음
+3. **Defect Protocol**: API-level 실패 테스트 -> 최소 재현 테스트 -> 둘 다 통과
+4. **한 커밋 = 한 논리 단위**: 테스트 통과 상태에서만 커밋
+5. **프로젝트 강제 규칙**:
+   - **public API만 테스트** (private 메서드 테스트 금지, public 테스트로 간접 검증)
+   - **Reflection 금지**
+   - **RED 단계 임시 구현 허용**: 컴파일만 되는 최소 임시 구현(`return null;`, `throw new UnsupportedOperationException("TODO");` 등)으로 "실행 실패(RED)"를 만든다.
+
+---
+
+## Scope
+
+### Goals
+
+- P1: ShopMenu(매장별 메뉴) 엔티티 + CRUD API
+- P2: Tag(태그) + 태그 기반 메뉴 필터링 API
+- P3: ShopMenuInputField(메뉴별 추가 입력 필드) 엔티티 + CRUD API
+- P4: 예약 생성 시 메뉴 선택 + 입력값 저장 (ReservationMenuItem + ReservationMenuInputValue)
+- P5: 예약 조회 시 메뉴/입력값 포함 응답
+
+### Non-goals
+
+- `formDataJson` 완전 제거 (Cleanup 단계 — 별도 이슈)
+- 메뉴별 가격 관리 (현재 ERD에 없음)
+- 메뉴 이미지 관리
+
+---
+
+## Test List
+
+### Phase 1-A: ShopMenu 엔티티 + 저장
+
+> **정책**: ShopMenu = 매장별 메뉴. `shop_menus` 테이블에 매핑. `UNIQUE(shop_id, name)`.
+
+- [x] **1-A-1**: `ShopMenu` 엔티티가 `shop_menus` 테이블에 매핑된다
+  - **목적**: DB 테이블과 엔티티 매핑 확인
+  - **입력**: `ShopMenu(shopId=1, name="젤네일", isActive=true, sortOrder=0)`
+  - **출력**: DB에 저장 후 조회 성공, id 할당됨
+  - **엣지케이스**: `shopId` null -> 예외, `name` null -> 예외
+
+- [x] **1-A-2**: 같은 shop에 동일 이름의 메뉴 생성 시 UNIQUE 위반 예외가 발생한다
+  - **목적**: 메뉴 이름 중복 방지
+  - **입력**: shopId=1, name="젤네일" 2회 저장
+  - **출력**: `DataIntegrityViolationException`
+  - **엣지케이스**: 다른 shop(shopId=2)에 동일 이름 -> 허용
+
+---
+
+### Phase 1-B: ShopMenu Reader/Writer
+
+- [ ] **1-B-1**: `ShopMenuWriter.save()`가 메뉴를 저장하고 ID를 할당한다
+  - **목적**: Writer 계층 동작 확인
+  - **입력**: `ShopMenu` 엔티티
+  - **출력**: 저장된 `ShopMenu` (id 할당됨)
+
+- [ ] **1-B-2**: `ShopMenuReader.findActiveByShopId(shopId)`가 해당 shop의 활성 메뉴를 sort_order 순으로 반환한다
+  - **목적**: 매장별 메뉴 목록 조회
+  - **입력**: shopId (활성 메뉴 3개 + 비활성 1개 존재)
+  - **출력**: 활성 메뉴 3개만 sort_order 오름차순
+  - **엣지케이스**: 메뉴 없으면 빈 리스트
+
+- [ ] **1-B-3**: `ShopMenuReader.getById(id)`가 메뉴를 반환한다
+  - **목적**: 단일 메뉴 조회
+  - **입력**: 존재하는 id
+  - **출력**: 해당 `ShopMenu`
+  - **엣지케이스**: 존재하지 않는 id -> 예외 (`ShopMenuNotFoundException` 또는 유사)
+
+---
+
+### Phase 1-C: ShopMenu CRUD API
+
+- [ ] **1-C-1**: `POST /api/shops/{shopId}/menus` 메뉴 생성 API
+  - **목적**: 점주가 메뉴를 생성
+  - **입력**: `{ "name": "젤네일", "description": "기본 젤네일", "sortOrder": 0 }`
+  - **출력**: 201 Created + 생성된 메뉴 정보
+  - **엣지케이스**:
+    - name 빈 문자열 -> 400
+    - 동일 이름 중복 -> 409
+    - 인증 없음 -> 401
+    - 다른 shop 소유자 -> 403
+
+- [ ] **1-C-2**: `GET /api/shops/{shopId}/menus` 메뉴 목록 조회 API
+  - **목적**: 매장의 활성 메뉴 목록
+  - **입력**: shopId
+  - **출력**: 200 OK + 활성 메뉴 리스트 (sort_order 순)
+  - **엣지케이스**: 메뉴 없으면 빈 배열
+
+- [ ] **1-C-3**: `PATCH /api/shops/{shopId}/menus/{menuId}` 메뉴 수정 API
+  - **목적**: 메뉴 이름/설명/정렬순서 수정
+  - **입력**: `{ "name": "젤네일(수정)", "description": "업데이트", "sortOrder": 1 }`
+  - **출력**: 200 OK + 수정된 메뉴 정보
+  - **엣지케이스**:
+    - 존재하지 않는 menuId -> 404
+    - 변경 후 이름 중복 -> 409
+    - 다른 shop의 메뉴 -> 403/404
+
+- [ ] **1-C-4**: `DELETE /api/shops/{shopId}/menus/{menuId}` 메뉴 비활성화 API
+  - **목적**: soft delete (is_active = false)
+  - **입력**: 존재하는 메뉴 menuId
+  - **출력**: 200 OK (또는 204 No Content)
+  - **엣지케이스**:
+    - 이미 비활성인 메뉴 -> 멱등 (성공)
+    - 존재하지 않는 menuId -> 404
+
+---
+
+### Phase 2-A: Tag 엔티티 + 저장
+
+> **정책**: Tag = 전역 태그. `UNIQUE(name)`. 태그는 shop에 종속되지 않음.
+
+- [ ] **2-A-1**: `Tag` 엔티티가 `tags` 테이블에 매핑된다
+  - **목적**: DB 테이블과 엔티티 매핑 확인
+  - **입력**: `Tag(name="손관리")`
+  - **출력**: DB에 저장 후 조회 성공, id 할당됨
+  - **엣지케이스**: `name` null -> 예외
+
+- [ ] **2-A-2**: 동일 이름 태그 생성 시 UNIQUE 위반 예외가 발생한다
+  - **목적**: 태그 이름 중복 방지
+  - **입력**: name="손관리" 2회 저장
+  - **출력**: `DataIntegrityViolationException`
+
+---
+
+### Phase 2-B: ShopMenuTag 엔티티 + 메뉴-태그 연결
+
+- [ ] **2-B-1**: `ShopMenuTag` 엔티티가 `shop_menu_tags` 테이블에 매핑된다
+  - **목적**: 메뉴-태그 연결 확인
+  - **입력**: `ShopMenuTag(shopMenuId=1, tagId=1)`
+  - **출력**: DB에 저장 후 조회 성공
+
+- [ ] **2-B-2**: 동일 (메뉴, 태그) 중복 연결 시 UNIQUE 위반 예외가 발생한다
+  - **목적**: 중복 연결 방지
+  - **입력**: (shopMenuId=1, tagId=1) 2회 저장
+  - **출력**: `DataIntegrityViolationException`
+  - **엣지케이스**: 같은 메뉴에 다른 태그 -> 허용, 같은 태그에 다른 메뉴 -> 허용
+
+---
+
+### Phase 2-C: 태그 기반 메뉴 필터링
+
+- [ ] **2-C-1**: `ShopMenuReader.findActiveByShopIdAndTagIds(shopId, tagIds)` 태그로 메뉴 필터링
+  - **목적**: 태그 기반 메뉴 검색
+  - **입력**: shopId=1, tagIds=[1] (태그 "손관리"가 달린 메뉴 2개 존재)
+  - **출력**: 해당 태그가 있는 활성 메뉴 2개
+  - **엣지케이스**:
+    - tagIds 여러 개 -> OR 필터 (하나라도 있는 메뉴)
+    - 존재하지 않는 tagId -> 빈 결과
+    - 태그 없는 메뉴 -> 필터 시 제외
+    - 비활성 메뉴 -> 무조건 제외
+
+- [ ] **2-C-2**: `GET /api/shops/{shopId}/menus?tagIds=1,2` 태그 필터 API
+  - **목적**: API 레벨 태그 필터링
+  - **입력**: shopId + tagIds 쿼리 파라미터
+  - **출력**: 200 OK + 필터된 메뉴 리스트
+  - **엣지케이스**:
+    - tagIds 미지정 -> 전체 활성 메뉴 반환 (기존 1-C-2와 동일)
+    - tagIds 빈 배열 -> 전체 활성 메뉴 반환
+
+---
+
+### Phase 2-D: 태그 관리 API
+
+- [ ] **2-D-1**: `POST /api/tags` 태그 생성 API
+  - **목적**: 태그 생성
+  - **입력**: `{ "name": "손관리" }`
+  - **출력**: 201 Created + 태그 정보
+  - **엣지케이스**:
+    - 동일 이름 태그 존재 -> 기존 태그 반환 (idempotent) 또는 409
+    - name 빈 문자열 -> 400
+
+- [ ] **2-D-2**: `POST /api/shops/{shopId}/menus/{menuId}/tags` 메뉴에 태그 연결 API
+  - **목적**: 메뉴에 태그 추가
+  - **입력**: `{ "tagId": 1 }`
+  - **출력**: 200 OK
+  - **엣지케이스**:
+    - 이미 연결된 태그 -> 멱등 또는 409
+    - 존재하지 않는 tagId -> 404
+    - 다른 shop 메뉴 -> 403
+
+- [ ] **2-D-3**: `DELETE /api/shops/{shopId}/menus/{menuId}/tags/{tagId}` 메뉴에서 태그 제거 API
+  - **목적**: 메뉴-태그 연결 해제
+  - **입력**: menuId + tagId
+  - **출력**: 200 OK (또는 204)
+  - **엣지케이스**: 연결되지 않은 태그 -> 멱등 (성공)
+
+- [ ] **2-D-4**: `GET /api/tags` 전체 태그 목록 조회 API
+  - **목적**: 사용 가능한 태그 목록
+  - **출력**: 200 OK + 태그 리스트
+  - **엣지케이스**: 태그 없으면 빈 배열
+
+---
+
+### Phase 3-A: ShopMenuInputField 엔티티 + 저장
+
+> **정책**: 메뉴별 추가 입력 필드 정의. `input_type` = NUMBER 또는 TEXT. `UNIQUE(shop_menu_id, label)`. `key` 컬럼 없음 (id로 식별).
+
+- [ ] **3-A-1**: `ShopMenuInputField` 엔티티가 `shop_menu_input_fields` 테이블에 매핑된다
+  - **목적**: DB 매핑 확인
+  - **입력**: `ShopMenuInputField(shopMenuId=1, label="갯수", inputType=NUMBER, required=true, sortOrder=0)`
+  - **출력**: DB에 저장 후 조회 성공
+  - **엣지케이스**: shopMenuId null -> 예외, label null -> 예외
+
+- [ ] **3-A-2**: 같은 메뉴에 동일 label 중복 생성 시 UNIQUE 위반 예외
+  - **목적**: 필드 label 중복 방지
+  - **입력**: (shopMenuId=1, label="갯수") 2회 저장
+  - **출력**: `DataIntegrityViolationException`
+  - **엣지케이스**: 다른 메뉴(shopMenuId=2)에 동일 label -> 허용
+
+- [ ] **3-A-3**: `inputType`이 NUMBER 또는 TEXT가 아니면 예외
+  - **목적**: 타입 제한 검증
+  - **입력**: inputType="CHECKBOX"
+  - **출력**: 검증 실패/예외
+
+---
+
+### Phase 3-B: ShopMenuInputField 검증 로직
+
+- [ ] **3-B-1**: NUMBER 타입에서 `minValue > maxValue`이면 검증 실패
+  - **목적**: 범위 논리 검증
+  - **입력**: inputType=NUMBER, minValue=10, maxValue=5
+  - **출력**: 검증 실패
+  - **엣지케이스**: minValue == maxValue -> 허용 (고정값)
+
+- [ ] **3-B-2**: NUMBER 타입에서 `stepValue <= 0`이면 검증 실패
+  - **목적**: step 양수 보장
+  - **입력**: inputType=NUMBER, stepValue=0
+  - **출력**: 검증 실패
+  - **엣지케이스**: stepValue null -> 허용 (step 제한 없음)
+
+- [ ] **3-B-3**: TEXT 타입에서 `maxLength <= 0`이면 검증 실패
+  - **목적**: 최대 길이 양수 보장
+  - **입력**: inputType=TEXT, maxLength=0
+  - **출력**: 검증 실패
+  - **엣지케이스**: maxLength null -> 허용 (길이 제한 없음)
+
+- [ ] **3-B-4**: TEXT 타입에 `minValue/maxValue/stepValue` 설정 시 무시한다
+  - **목적**: 타입별 필드 정합성
+  - **입력**: inputType=TEXT, minValue=1
+  - **출력**: 저장 후 minValue=null
+
+- [ ] **3-B-5**: NUMBER 타입에 `maxLength` 설정 시 무시한다
+  - **목적**: 타입별 필드 정합성
+  - **입력**: inputType=NUMBER, maxLength=100
+  - **출력**: 저장 후 maxLength=null
+
+---
+
+### Phase 3-C: ShopMenuInputField CRUD API
+
+- [ ] **3-C-1**: `POST /api/shops/{shopId}/menus/{menuId}/input-fields` 입력 필드 생성 API
+  - **목적**: 메뉴에 추가 입력 필드 정의
+  - **입력**: `{ "label": "손연장 갯수", "inputType": "NUMBER", "required": true, "minValue": 1, "maxValue": 10, "stepValue": 1, "sortOrder": 0 }`
+  - **출력**: 201 Created + 생성된 필드 정보
+  - **엣지케이스**:
+    - 동일 label 중복 -> 409
+    - 존재하지 않는 menuId -> 404
+    - 다른 shop의 메뉴 -> 403
+
+- [ ] **3-C-2**: `GET /api/shops/{shopId}/menus/{menuId}/input-fields` 입력 필드 목록 조회 API
+  - **목적**: 메뉴의 활성 입력 필드 목록
+  - **입력**: menuId
+  - **출력**: 200 OK + 활성 필드 리스트 (sort_order 순)
+  - **엣지케이스**: 필드 없으면 빈 배열
+
+- [ ] **3-C-3**: `PATCH /api/shops/{shopId}/menus/{menuId}/input-fields/{id}` 입력 필드 수정 API
+  - **목적**: 필드 속성 수정
+  - **출력**: 200 OK
+  - **엣지케이스**: label 변경 후 중복 -> 409
+
+- [ ] **3-C-4**: `DELETE /api/shops/{shopId}/menus/{menuId}/input-fields/{id}` 입력 필드 비활성화 API
+  - **목적**: soft delete
+  - **출력**: 200 OK (또는 204)
+  - **엣지케이스**: 이미 비활성 -> 멱등
+
+---
+
+### Phase 4-A: ReservationMenuItem 엔티티 + 저장
+
+> **정책**: 예약-메뉴 다중 선택. `UNIQUE(reservation_id, shop_menu_id)`. 메뉴 이름/설명은 스냅샷 저장.
+
+- [ ] **4-A-1**: `ReservationMenuItem` 엔티티가 `reservation_menu_items` 테이블에 매핑된다
+  - **목적**: DB 매핑 확인
+  - **입력**: `ReservationMenuItem(reservationId=1, shopMenuId=1, menuNameSnapshot="젤네일", sortOrder=0)`
+  - **출력**: DB에 저장 후 조회 성공
+  - **엣지케이스**: reservationId null -> 예외, shopMenuId null -> 예외
+
+- [ ] **4-A-2**: 같은 예약에 동일 메뉴 중복 선택 시 UNIQUE 위반 예외
+  - **목적**: 메뉴 중복 선택 방지
+  - **입력**: (reservationId=1, shopMenuId=1) 2회 저장
+  - **출력**: `DataIntegrityViolationException`
+  - **엣지케이스**: 다른 예약(reservationId=2)에 동일 메뉴 -> 허용
+
+---
+
+### Phase 4-B: ReservationMenuInputValue 엔티티 + 저장
+
+- [ ] **4-B-1**: `ReservationMenuInputValue` 엔티티가 `reservation_menu_input_values` 테이블에 매핑된다
+  - **목적**: DB 매핑 확인
+  - **입력**: `ReservationMenuInputValue(reservationMenuItemId=1, shopMenuInputFieldId=1, fieldLabelSnapshot="갯수", inputTypeSnapshot="NUMBER", valueNumber=5)`
+  - **출력**: DB에 저장 후 조회 성공
+
+- [ ] **4-B-2**: 동일 (reservationMenuItemId, shopMenuInputFieldId) 중복 시 UNIQUE 위반 예외
+  - **목적**: 입력값 중복 방지
+  - **입력**: 동일 조합 2회 저장
+  - **출력**: `DataIntegrityViolationException`
+
+---
+
+### Phase 4-C: 예약 생성 시 메뉴 선택 비즈니스 로직
+
+- [ ] **4-C-1**: 예약 생성 시 선택한 메뉴 목록이 `reservation_menu_items`에 저장된다
+  - **목적**: 메뉴 다중 선택 저장
+  - **입력**: 예약 생성 요청 + menuIds=[1, 2]
+  - **출력**: reservation_menu_items에 2건 저장, 스냅샷(이름/설명) 포함
+  - **관측**: reservationId가 올바르게 연결됨
+
+- [ ] **4-C-2**: 메뉴 0개 선택 시 예외가 발생한다
+  - **목적**: 최소 1개 메뉴 필수 검증
+  - **입력**: menuIds=[] (빈 배열)
+  - **출력**: 검증 실패/예외
+  - **엣지케이스**: menuIds=null -> 예외
+
+- [ ] **4-C-3**: 다른 shop의 메뉴 선택 시 예외가 발생한다
+  - **목적**: shop 소속 검증
+  - **입력**: shopId=1 예약인데 shopId=2의 메뉴 포함
+  - **출력**: 예외 (InvalidShopMenuException 또는 유사)
+
+- [ ] **4-C-4**: 비활성(is_active=false) 메뉴 선택 시 예외가 발생한다
+  - **목적**: 활성 메뉴만 선택 가능
+  - **입력**: is_active=false인 메뉴 ID
+  - **출력**: 예외
+
+- [ ] **4-C-5**: 메뉴 이름/설명이 스냅샷으로 저장되어 원본 변경과 무관하게 보존된다
+  - **목적**: 스냅샷 정합성
+  - **입력**: 메뉴 "젤네일"로 예약 생성 -> 메뉴 이름을 "젤아트"로 변경
+  - **출력**: 예약 조회 시 스냅샷은 "젤네일" 유지
+
+---
+
+### Phase 4-D: 예약 생성 시 입력값 저장 비즈니스 로직
+
+- [ ] **4-D-1**: 메뉴별 추가 입력값이 `reservation_menu_input_values`에 저장된다
+  - **목적**: 입력값 저장 확인
+  - **입력**: menuId=1에 대해 `{ fieldId: 1, value: 5 }` (NUMBER 타입)
+  - **출력**: reservation_menu_input_values에 저장, 스냅샷(label/type) 포함
+  - **관측**: valueNumber=5, valueText=null
+
+- [ ] **4-D-2**: required 필드 값 누락 시 검증 실패
+  - **목적**: 필수 입력 검증
+  - **입력**: required=true 필드에 값 미제공
+  - **출력**: 검증 실패/예외
+
+- [ ] **4-D-3**: NUMBER 타입에서 min_value~max_value 범위 초과 시 검증 실패
+  - **목적**: 범위 검증
+  - **입력**: minValue=1, maxValue=10인 필드에 value=15
+  - **출력**: 검증 실패
+  - **엣지케이스**:
+    - value=1 (경계값 하한) -> 허용
+    - value=10 (경계값 상한) -> 허용
+    - value=0 (하한 미만) -> 실패
+
+- [ ] **4-D-4**: NUMBER 타입에서 step_value 미준수 시 검증 실패
+  - **목적**: step 검증
+  - **입력**: minValue=0, stepValue=5인 필드에 value=3
+  - **출력**: 검증 실패
+  - **엣지케이스**:
+    - value=5 -> 허용
+    - value=10 -> 허용
+    - stepValue=null -> step 검증 건너뜀
+
+- [ ] **4-D-5**: TEXT 타입에서 max_length 초과 시 검증 실패
+  - **목적**: 길이 검증
+  - **입력**: maxLength=100인 필드에 101자 텍스트
+  - **출력**: 검증 실패
+  - **엣지케이스**:
+    - 100자 -> 허용 (경계값)
+    - maxLength=null -> 검증 건너뜀
+
+- [ ] **4-D-6**: NUMBER 필드에 value_text만 있으면 예외가 발생한다
+  - **목적**: 타입 매칭 검증
+  - **입력**: inputType=NUMBER 필드에 valueText="hello"
+  - **출력**: 예외
+  - **엣지케이스**: TEXT 필드에 valueNumber만 -> 예외
+
+- [ ] **4-D-7**: 해당 메뉴에 정의되지 않은 input_field_id에 값 입력 시 예외가 발생한다
+  - **목적**: 필드 소속 검증
+  - **입력**: menuId=1의 메뉴인데 menuId=2에 정의된 fieldId 사용
+  - **출력**: 예외
+
+---
+
+### Phase 4-E: Dual-write (formDataJson 호환)
+
+- [ ] **4-E-1**: 예약 생성 시 `formDataJson`도 함께 저장된다 (레거시 호환)
+  - **목적**: 기존 프론트엔드 호환 유지
+  - **입력**: 메뉴 선택 + 입력값 포함 예약 생성
+  - **출력**: `reservation.formDataJson`에 레거시 포맷 JSON 저장
+  - **관측**: reservation_menu_items + reservation_menu_input_values도 동시 저장
+
+- [ ] **4-E-2**: `reservation_menu_items` 저장 실패 시 전체 트랜잭션이 롤백된다
+  - **목적**: 데이터 정합성 보장
+  - **입력**: 유효한 예약 + 잘못된 메뉴 데이터 (UNIQUE 위반 유발)
+  - **출력**: 전체 롤백, formDataJson도 저장 안 됨
+
+---
+
+### Phase 5-A: 예약 조회 시 메뉴/입력값 응답
+
+- [ ] **5-A-1**: 예약 상세 조회 시 선택된 메뉴 목록 + 입력값이 포함된다
+  - **목적**: 메뉴 정보를 포함한 조회
+  - **입력**: 메뉴 2개 + 입력값 포함된 예약 조회
+  - **출력**: 응답에 `menus` 배열 (메뉴별 inputValues 중첩 포함)
+
+- [ ] **5-A-2**: `reservation_menu_items` 데이터가 없으면 `formDataJson` fallback
+  - **목적**: 기존 예약 호환
+  - **입력**: reservation_menu_items 없는 기존 예약 조회
+  - **출력**: formDataJson 기반 응답 반환
+
+- [ ] **5-A-3**: 메뉴별 입력값이 해당 메뉴 하위로 중첩 반환된다
+  - **목적**: 응답 구조 확인
+  - **입력**: 메뉴 A (입력값 2개), 메뉴 B (입력값 0개)
+  - **출력**: 메뉴 A -> inputValues[2], 메뉴 B -> inputValues[]
+
+---
+
+## Notes
+
+### DB 테이블 리네이밍 + key 제거 (V4 마이그레이션)
+
+- Flyway V1~V3에서 `shop_services` 계열로 생성
+- V4에서 `shop_menus` 계열로 리네이밍 + `key` 컬럼 제거 + `field_key_snapshot` 제거
+- 입력 필드 식별: `id`(PK) 사용, `UNIQUE(shop_menu_id, label)`로 중복 방지
+- 마이그레이션: `V4__rename_shop_services_to_shop_menus.sql`
+
+### 모호한 요구사항/질문 목록
+
+1. **태그 여러 개 필터 정책**: AND vs OR
+   - 잠정: OR (하나라도 있으면 포함)
+   - 근거: 사용자 편의성, AND 필터는 결과가 지나치게 좁아질 수 있음
+
+-> 태그는 하나만 선택 가능
+
+2. **메뉴 0개 선택 허용 여부**
+   - 잠정: 불허 (최소 1개 필수)
+   - 근거: 예약 목적상 메뉴 없는 예약은 의미 없음
+  
+  -> 허용 안하지 당연히
+
+3. **동일 메뉴 중복 선택 허용 여부**
+   - 확정: 불허 (`UNIQUE(reservation_id, shop_menu_id)` 적용됨 — V3 + V4 마이그레이션)
+
+
+4. **태그 생성 정책 (idempotent vs reject)**
+   - 잠정: idempotent (이미 존재하면 기존 태그 반환)
+   - 근거: 사용 편의성, 동시성 문제 완화
+
+---
+
+## 진행 상태
+
+| Phase | 상태 | 비고 |
+|-------|------|------|
+| Phase 1-A | 대기 | ShopMenu 엔티티 |
+| Phase 1-B | 대기 | ShopMenu Reader/Writer |
+| Phase 1-C | 대기 | ShopMenu CRUD API |
+| Phase 2-A | 대기 | Tag 엔티티 |
+| Phase 2-B | 대기 | ShopMenuTag 엔티티 |
+| Phase 2-C | 대기 | 태그 필터링 |
+| Phase 2-D | 대기 | 태그 관리 API |
+| Phase 3-A | 대기 | ShopMenuInputField 엔티티 |
+| Phase 3-B | 대기 | ShopMenuInputField 검증 |
+| Phase 3-C | 대기 | ShopMenuInputField CRUD API |
+| Phase 4-A | 대기 | ReservationMenuItem 엔티티 |
+| Phase 4-B | 대기 | ReservationMenuInputValue 엔티티 |
+| Phase 4-C | 대기 | 예약-메뉴 선택 로직 |
+| Phase 4-D | 대기 | 예약-입력값 저장 로직 |
+| Phase 4-E | 대기 | Dual-write |
+| Phase 5-A | 대기 | 조회 응답 |
+
+---
+
+## 관련 문서
+
+- 설계안: `docs/issues/#99/02-design/design-plan.md`
+- ERD v2: `docs/issues/#97/reservation-erd-v2.md`
+- #97 TDD plan: `docs/issues/#97/04-tdd/plan.md`
+- Flyway V1: `src/main/resources/db/migration/V1__reservation_v2_phase1_add_tables_and_columns.sql`
+- Flyway V3: `src/main/resources/db/migration/V3__reservation_v2_phase3_constraints_and_indexes.sql`
+- Flyway V4 (리네이밍 + key 제거): `src/main/resources/db/migration/V4__rename_shop_services_to_shop_menus.sql`

--- a/docs/issues/#99/04-tdd/plan.md
+++ b/docs/issues/#99/04-tdd/plan.md
@@ -60,18 +60,18 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 ### Phase 1-B: ShopMenu Reader/Writer
 
-- [ ] **1-B-1**: `ShopMenuWriter.save()`가 메뉴를 저장하고 ID를 할당한다
+- [x] **1-B-1**: `ShopMenuWriter.save()`가 메뉴를 저장하고 ID를 할당한다
   - **목적**: Writer 계층 동작 확인
   - **입력**: `ShopMenu` 엔티티
   - **출력**: 저장된 `ShopMenu` (id 할당됨)
 
-- [ ] **1-B-2**: `ShopMenuReader.findActiveByShopId(shopId)`가 해당 shop의 활성 메뉴를 sort_order 순으로 반환한다
+- [x] **1-B-2**: `ShopMenuReader.findActiveByShopId(shopId)`가 해당 shop의 활성 메뉴를 sort_order 순으로 반환한다
   - **목적**: 매장별 메뉴 목록 조회
   - **입력**: shopId (활성 메뉴 3개 + 비활성 1개 존재)
   - **출력**: 활성 메뉴 3개만 sort_order 오름차순
   - **엣지케이스**: 메뉴 없으면 빈 리스트
 
-- [ ] **1-B-3**: `ShopMenuReader.getById(id)`가 메뉴를 반환한다
+- [x] **1-B-3**: `ShopMenuReader.getById(id)`가 메뉴를 반환한다
   - **목적**: 단일 메뉴 조회
   - **입력**: 존재하는 id
   - **출력**: 해당 `ShopMenu`
@@ -81,7 +81,7 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 ### Phase 1-C: ShopMenu CRUD API
 
-- [ ] **1-C-1**: `POST /api/shops/{shopId}/menus` 메뉴 생성 API
+- [x] **1-C-1**: `POST /api/shops/{shopId}/menus` 메뉴 생성 API
   - **목적**: 점주가 메뉴를 생성
   - **입력**: `{ "name": "젤네일", "description": "기본 젤네일", "sortOrder": 0 }`
   - **출력**: 201 Created + 생성된 메뉴 정보
@@ -91,13 +91,13 @@ Design: `docs/issues/#99/02-design/design-plan.md`
     - 인증 없음 -> 401
     - 다른 shop 소유자 -> 403
 
-- [ ] **1-C-2**: `GET /api/shops/{shopId}/menus` 메뉴 목록 조회 API
+- [x] **1-C-2**: `GET /api/shops/{shopId}/menus` 메뉴 목록 조회 API
   - **목적**: 매장의 활성 메뉴 목록
   - **입력**: shopId
   - **출력**: 200 OK + 활성 메뉴 리스트 (sort_order 순)
   - **엣지케이스**: 메뉴 없으면 빈 배열
 
-- [ ] **1-C-3**: `PATCH /api/shops/{shopId}/menus/{menuId}` 메뉴 수정 API
+- [x] **1-C-3**: `PATCH /api/shops/{shopId}/menus/{menuId}` 메뉴 수정 API
   - **목적**: 메뉴 이름/설명/정렬순서 수정
   - **입력**: `{ "name": "젤네일(수정)", "description": "업데이트", "sortOrder": 1 }`
   - **출력**: 200 OK + 수정된 메뉴 정보
@@ -106,7 +106,7 @@ Design: `docs/issues/#99/02-design/design-plan.md`
     - 변경 후 이름 중복 -> 409
     - 다른 shop의 메뉴 -> 403/404
 
-- [ ] **1-C-4**: `DELETE /api/shops/{shopId}/menus/{menuId}` 메뉴 비활성화 API
+- [x] **1-C-4**: `DELETE /api/shops/{shopId}/menus/{menuId}` 메뉴 비활성화 API
   - **목적**: soft delete (is_active = false)
   - **입력**: 존재하는 메뉴 menuId
   - **출력**: 200 OK (또는 204 No Content)

--- a/docs/issues/#99/04-tdd/plan.md
+++ b/docs/issues/#99/04-tdd/plan.md
@@ -206,19 +206,19 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 > **정책**: 메뉴별 추가 입력 필드 정의. `input_type` = NUMBER 또는 TEXT. `UNIQUE(shop_menu_id, label)`. `key` 컬럼 없음 (id로 식별).
 
-- [ ] **3-A-1**: `ShopMenuInputField` 엔티티가 `shop_menu_input_fields` 테이블에 매핑된다
+- [x] **3-A-1**: `ShopMenuInputField` 엔티티가 `shop_menu_input_fields` 테이블에 매핑된다
   - **목적**: DB 매핑 확인
   - **입력**: `ShopMenuInputField(shopMenuId=1, label="갯수", inputType=NUMBER, required=true, sortOrder=0)`
   - **출력**: DB에 저장 후 조회 성공
   - **엣지케이스**: shopMenuId null -> 예외, label null -> 예외
 
-- [ ] **3-A-2**: 같은 메뉴에 동일 label 중복 생성 시 UNIQUE 위반 예외
+- [x] **3-A-2**: 같은 메뉴에 동일 label 중복 생성 시 UNIQUE 위반 예외
   - **목적**: 필드 label 중복 방지
   - **입력**: (shopMenuId=1, label="갯수") 2회 저장
   - **출력**: `DataIntegrityViolationException`
   - **엣지케이스**: 다른 메뉴(shopMenuId=2)에 동일 label -> 허용
 
-- [ ] **3-A-3**: `inputType`이 NUMBER 또는 TEXT가 아니면 예외
+- [x] **3-A-3**: `inputType`이 NUMBER 또는 TEXT가 아니면 예외
   - **목적**: 타입 제한 검증
   - **입력**: inputType="CHECKBOX"
   - **출력**: 검증 실패/예외
@@ -227,30 +227,30 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 ### Phase 3-B: ShopMenuInputField 검증 로직
 
-- [ ] **3-B-1**: NUMBER 타입에서 `minValue > maxValue`이면 검증 실패
+- [x] **3-B-1**: NUMBER 타입에서 `minValue > maxValue`이면 검증 실패
   - **목적**: 범위 논리 검증
   - **입력**: inputType=NUMBER, minValue=10, maxValue=5
   - **출력**: 검증 실패
   - **엣지케이스**: minValue == maxValue -> 허용 (고정값)
 
-- [ ] **3-B-2**: NUMBER 타입에서 `stepValue <= 0`이면 검증 실패
+- [x] **3-B-2**: NUMBER 타입에서 `stepValue <= 0`이면 검증 실패
   - **목적**: step 양수 보장
   - **입력**: inputType=NUMBER, stepValue=0
   - **출력**: 검증 실패
   - **엣지케이스**: stepValue null -> 허용 (step 제한 없음)
 
-- [ ] **3-B-3**: TEXT 타입에서 `maxLength <= 0`이면 검증 실패
+- [x] **3-B-3**: TEXT 타입에서 `maxLength <= 0`이면 검증 실패
   - **목적**: 최대 길이 양수 보장
   - **입력**: inputType=TEXT, maxLength=0
   - **출력**: 검증 실패
   - **엣지케이스**: maxLength null -> 허용 (길이 제한 없음)
 
-- [ ] **3-B-4**: TEXT 타입에 `minValue/maxValue/stepValue` 설정 시 무시한다
+- [x] **3-B-4**: TEXT 타입에 `minValue/maxValue/stepValue` 설정 시 무시한다
   - **목적**: 타입별 필드 정합성
   - **입력**: inputType=TEXT, minValue=1
   - **출력**: 저장 후 minValue=null
 
-- [ ] **3-B-5**: NUMBER 타입에 `maxLength` 설정 시 무시한다
+- [x] **3-B-5**: NUMBER 타입에 `maxLength` 설정 시 무시한다
   - **목적**: 타입별 필드 정합성
   - **입력**: inputType=NUMBER, maxLength=100
   - **출력**: 저장 후 maxLength=null
@@ -259,7 +259,7 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 ### Phase 3-C: ShopMenuInputField CRUD API
 
-- [ ] **3-C-1**: `POST /api/shops/{shopId}/menus/{menuId}/input-fields` 입력 필드 생성 API
+- [x] **3-C-1**: `POST /api/shops/{shopId}/menus/{menuId}/input-fields` 입력 필드 생성 API
   - **목적**: 메뉴에 추가 입력 필드 정의
   - **입력**: `{ "label": "손연장 갯수", "inputType": "NUMBER", "required": true, "minValue": 1, "maxValue": 10, "stepValue": 1, "sortOrder": 0 }`
   - **출력**: 201 Created + 생성된 필드 정보
@@ -268,18 +268,18 @@ Design: `docs/issues/#99/02-design/design-plan.md`
     - 존재하지 않는 menuId -> 404
     - 다른 shop의 메뉴 -> 403
 
-- [ ] **3-C-2**: `GET /api/shops/{shopId}/menus/{menuId}/input-fields` 입력 필드 목록 조회 API
+- [x] **3-C-2**: `GET /api/shops/{shopId}/menus/{menuId}/input-fields` 입력 필드 목록 조회 API
   - **목적**: 메뉴의 활성 입력 필드 목록
   - **입력**: menuId
   - **출력**: 200 OK + 활성 필드 리스트 (sort_order 순)
   - **엣지케이스**: 필드 없으면 빈 배열
 
-- [ ] **3-C-3**: `PATCH /api/shops/{shopId}/menus/{menuId}/input-fields/{id}` 입력 필드 수정 API
+- [x] **3-C-3**: `PATCH /api/shops/{shopId}/menus/{menuId}/input-fields/{id}` 입력 필드 수정 API
   - **목적**: 필드 속성 수정
   - **출력**: 200 OK
   - **엣지케이스**: label 변경 후 중복 -> 409
 
-- [ ] **3-C-4**: `DELETE /api/shops/{shopId}/menus/{menuId}/input-fields/{id}` 입력 필드 비활성화 API
+- [x] **3-C-4**: `DELETE /api/shops/{shopId}/menus/{menuId}/input-fields/{id}` 입력 필드 비활성화 API
   - **목적**: soft delete
   - **출력**: 200 OK (또는 204)
   - **엣지케이스**: 이미 비활성 -> 멱등

--- a/docs/issues/#99/04-tdd/plan.md
+++ b/docs/issues/#99/04-tdd/plan.md
@@ -120,13 +120,13 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 > **정책**: Tag = 전역 태그. `UNIQUE(name)`. 태그는 shop에 종속되지 않음.
 
-- [ ] **2-A-1**: `Tag` 엔티티가 `tags` 테이블에 매핑된다
+- [x] **2-A-1**: `Tag` 엔티티가 `tags` 테이블에 매핑된다
   - **목적**: DB 테이블과 엔티티 매핑 확인
   - **입력**: `Tag(name="손관리")`
   - **출력**: DB에 저장 후 조회 성공, id 할당됨
   - **엣지케이스**: `name` null -> 예외
 
-- [ ] **2-A-2**: 동일 이름 태그 생성 시 UNIQUE 위반 예외가 발생한다
+- [x] **2-A-2**: 동일 이름 태그 생성 시 UNIQUE 위반 예외가 발생한다
   - **목적**: 태그 이름 중복 방지
   - **입력**: name="손관리" 2회 저장
   - **출력**: `DataIntegrityViolationException`
@@ -135,12 +135,12 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 ### Phase 2-B: ShopMenuTag 엔티티 + 메뉴-태그 연결
 
-- [ ] **2-B-1**: `ShopMenuTag` 엔티티가 `shop_menu_tags` 테이블에 매핑된다
+- [x] **2-B-1**: `ShopMenuTag` 엔티티가 `shop_menu_tags` 테이블에 매핑된다
   - **목적**: 메뉴-태그 연결 확인
   - **입력**: `ShopMenuTag(shopMenuId=1, tagId=1)`
   - **출력**: DB에 저장 후 조회 성공
 
-- [ ] **2-B-2**: 동일 (메뉴, 태그) 중복 연결 시 UNIQUE 위반 예외가 발생한다
+- [x] **2-B-2**: 동일 (메뉴, 태그) 중복 연결 시 UNIQUE 위반 예외가 발생한다
   - **목적**: 중복 연결 방지
   - **입력**: (shopMenuId=1, tagId=1) 2회 저장
   - **출력**: `DataIntegrityViolationException`
@@ -150,7 +150,7 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 ### Phase 2-C: 태그 기반 메뉴 필터링
 
-- [ ] **2-C-1**: `ShopMenuReader.findActiveByShopIdAndTagIds(shopId, tagIds)` 태그로 메뉴 필터링
+- [x] **2-C-1**: `ShopMenuReader.findActiveByShopIdAndTagIds(shopId, tagIds)` 태그로 메뉴 필터링
   - **목적**: 태그 기반 메뉴 검색
   - **입력**: shopId=1, tagIds=[1] (태그 "손관리"가 달린 메뉴 2개 존재)
   - **출력**: 해당 태그가 있는 활성 메뉴 2개
@@ -160,7 +160,7 @@ Design: `docs/issues/#99/02-design/design-plan.md`
     - 태그 없는 메뉴 -> 필터 시 제외
     - 비활성 메뉴 -> 무조건 제외
 
-- [ ] **2-C-2**: `GET /api/shops/{shopId}/menus?tagIds=1,2` 태그 필터 API
+- [x] **2-C-2**: `GET /api/shops/{shopId}/menus?tagIds=1,2` 태그 필터 API
   - **목적**: API 레벨 태그 필터링
   - **입력**: shopId + tagIds 쿼리 파라미터
   - **출력**: 200 OK + 필터된 메뉴 리스트
@@ -172,7 +172,7 @@ Design: `docs/issues/#99/02-design/design-plan.md`
 
 ### Phase 2-D: 태그 관리 API
 
-- [ ] **2-D-1**: `POST /api/tags` 태그 생성 API
+- [x] **2-D-1**: `POST /api/tags` 태그 생성 API
   - **목적**: 태그 생성
   - **입력**: `{ "name": "손관리" }`
   - **출력**: 201 Created + 태그 정보
@@ -180,7 +180,7 @@ Design: `docs/issues/#99/02-design/design-plan.md`
     - 동일 이름 태그 존재 -> 기존 태그 반환 (idempotent) 또는 409
     - name 빈 문자열 -> 400
 
-- [ ] **2-D-2**: `POST /api/shops/{shopId}/menus/{menuId}/tags` 메뉴에 태그 연결 API
+- [x] **2-D-2**: `POST /api/shops/{shopId}/menus/{menuId}/tags` 메뉴에 태그 연결 API
   - **목적**: 메뉴에 태그 추가
   - **입력**: `{ "tagId": 1 }`
   - **출력**: 200 OK
@@ -189,13 +189,13 @@ Design: `docs/issues/#99/02-design/design-plan.md`
     - 존재하지 않는 tagId -> 404
     - 다른 shop 메뉴 -> 403
 
-- [ ] **2-D-3**: `DELETE /api/shops/{shopId}/menus/{menuId}/tags/{tagId}` 메뉴에서 태그 제거 API
+- [x] **2-D-3**: `DELETE /api/shops/{shopId}/menus/{menuId}/tags/{tagId}` 메뉴에서 태그 제거 API
   - **목적**: 메뉴-태그 연결 해제
   - **입력**: menuId + tagId
   - **출력**: 200 OK (또는 204)
   - **엣지케이스**: 연결되지 않은 태그 -> 멱등 (성공)
 
-- [ ] **2-D-4**: `GET /api/tags` 전체 태그 목록 조회 API
+- [x] **2-D-4**: `GET /api/tags` 전체 태그 목록 조회 API
   - **목적**: 사용 가능한 태그 목록
   - **출력**: 200 OK + 태그 리스트
   - **엣지케이스**: 태그 없으면 빈 배열

--- a/src/main/java/com/example/easybooking/reservation/ReservationMenuInputValueReader.java
+++ b/src/main/java/com/example/easybooking/reservation/ReservationMenuInputValueReader.java
@@ -1,0 +1,21 @@
+package com.example.easybooking.reservation;
+
+import com.example.easybooking.reservation.domain.ReservationMenuInputValue;
+import com.example.easybooking.reservation.domain.repository.ReservationMenuInputValueRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationMenuInputValueReader {
+
+    private final ReservationMenuInputValueRepository repository;
+
+    public List<ReservationMenuInputValue> findByReservationMenuItemIds(List<Long> menuItemIds) {
+        if (menuItemIds == null || menuItemIds.isEmpty()) {
+            return List.of();
+        }
+        return repository.findByReservationMenuItemIdIn(menuItemIds);
+    }
+}

--- a/src/main/java/com/example/easybooking/reservation/ReservationMenuInputValueWriter.java
+++ b/src/main/java/com/example/easybooking/reservation/ReservationMenuInputValueWriter.java
@@ -1,0 +1,18 @@
+package com.example.easybooking.reservation;
+
+import com.example.easybooking.reservation.domain.ReservationMenuInputValue;
+import com.example.easybooking.reservation.domain.repository.ReservationMenuInputValueRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationMenuInputValueWriter {
+
+    private final ReservationMenuInputValueRepository repository;
+
+    public List<ReservationMenuInputValue> saveAll(List<ReservationMenuInputValue> values) {
+        return repository.saveAll(values);
+    }
+}

--- a/src/main/java/com/example/easybooking/reservation/ReservationMenuItemReader.java
+++ b/src/main/java/com/example/easybooking/reservation/ReservationMenuItemReader.java
@@ -1,0 +1,18 @@
+package com.example.easybooking.reservation;
+
+import com.example.easybooking.reservation.domain.ReservationMenuItem;
+import com.example.easybooking.reservation.domain.repository.ReservationMenuItemRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationMenuItemReader {
+
+    private final ReservationMenuItemRepository repository;
+
+    public List<ReservationMenuItem> findByReservationId(Long reservationId) {
+        return repository.findByReservationIdOrderBySortOrderAsc(reservationId);
+    }
+}

--- a/src/main/java/com/example/easybooking/reservation/ReservationMenuItemWriter.java
+++ b/src/main/java/com/example/easybooking/reservation/ReservationMenuItemWriter.java
@@ -1,0 +1,18 @@
+package com.example.easybooking.reservation;
+
+import com.example.easybooking.reservation.domain.ReservationMenuItem;
+import com.example.easybooking.reservation.domain.repository.ReservationMenuItemRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationMenuItemWriter {
+
+    private final ReservationMenuItemRepository repository;
+
+    public List<ReservationMenuItem> saveAll(List<ReservationMenuItem> items) {
+        return repository.saveAll(items);
+    }
+}

--- a/src/main/java/com/example/easybooking/reservation/domain/ReservationMenuInputValue.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/ReservationMenuInputValue.java
@@ -11,12 +11,19 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "reservation_menu_input_values")
+@Table(
+        name = "reservation_menu_input_values",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_res_menu_input_values",
+                columnNames = {"reservation_menu_item_id", "shop_menu_input_field_id"}
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReservationMenuInputValue {

--- a/src/main/java/com/example/easybooking/reservation/domain/ReservationMenuInputValue.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/ReservationMenuInputValue.java
@@ -1,0 +1,65 @@
+package com.example.easybooking.reservation.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "reservation_menu_input_values")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReservationMenuInputValue {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "reservation_menu_item_id", nullable = false)
+    private Long reservationMenuItemId;
+
+    @Column(name = "shop_menu_input_field_id", nullable = false)
+    private Long shopMenuInputFieldId;
+
+    @Column(name = "field_label_snapshot", nullable = false)
+    private String fieldLabelSnapshot;
+
+    @Column(name = "input_type_snapshot", nullable = false, length = 20)
+    private String inputTypeSnapshot;
+
+    @Column(name = "value_number", precision = 10, scale = 2)
+    private BigDecimal valueNumber;
+
+    @Column(name = "value_text")
+    private String valueText;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static ReservationMenuInputValue create(Long reservationMenuItemId,
+                                                   Long shopMenuInputFieldId,
+                                                   String fieldLabelSnapshot,
+                                                   String inputTypeSnapshot,
+                                                   BigDecimal valueNumber,
+                                                   String valueText) {
+        ReservationMenuInputValue value = new ReservationMenuInputValue();
+        value.reservationMenuItemId = reservationMenuItemId;
+        value.shopMenuInputFieldId = shopMenuInputFieldId;
+        value.fieldLabelSnapshot = fieldLabelSnapshot;
+        value.inputTypeSnapshot = inputTypeSnapshot;
+        value.valueNumber = valueNumber;
+        value.valueText = valueText;
+        return value;
+    }
+}

--- a/src/main/java/com/example/easybooking/reservation/domain/ReservationMenuItem.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/ReservationMenuItem.java
@@ -1,0 +1,57 @@
+package com.example.easybooking.reservation.domain;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "reservation_menu_items")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReservationMenuItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "reservation_id", nullable = false)
+    private Long reservationId;
+
+    @Column(name = "shop_menu_id", nullable = false)
+    private Long shopMenuId;
+
+    @Column(name = "menu_name_snapshot", nullable = false)
+    private String menuNameSnapshot;
+
+    @Column(name = "price_snapshot")
+    private Long priceSnapshot;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public static ReservationMenuItem create(Long reservationId, Long shopMenuId,
+                                             String menuNameSnapshot, Long priceSnapshot,
+                                             int sortOrder) {
+        ReservationMenuItem item = new ReservationMenuItem();
+        item.reservationId = reservationId;
+        item.shopMenuId = shopMenuId;
+        item.menuNameSnapshot = menuNameSnapshot;
+        item.priceSnapshot = priceSnapshot;
+        item.sortOrder = sortOrder;
+        return item;
+    }
+}

--- a/src/main/java/com/example/easybooking/reservation/domain/ReservationMenuItem.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/ReservationMenuItem.java
@@ -10,12 +10,19 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "reservation_menu_items")
+@Table(
+        name = "reservation_menu_items",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_reservation_menu_items_res_shop_menu",
+                columnNames = {"reservation_id", "shop_menu_id"}
+        )
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReservationMenuItem {

--- a/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationMenuInputValueRepository.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationMenuInputValueRepository.java
@@ -1,0 +1,7 @@
+package com.example.easybooking.reservation.domain.repository;
+
+import com.example.easybooking.reservation.domain.ReservationMenuInputValue;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationMenuInputValueRepository extends JpaRepository<ReservationMenuInputValue, Long> {
+}

--- a/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationMenuInputValueRepository.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationMenuInputValueRepository.java
@@ -1,7 +1,10 @@
 package com.example.easybooking.reservation.domain.repository;
 
 import com.example.easybooking.reservation.domain.ReservationMenuInputValue;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReservationMenuInputValueRepository extends JpaRepository<ReservationMenuInputValue, Long> {
+
+    List<ReservationMenuInputValue> findByReservationMenuItemIdIn(List<Long> reservationMenuItemIds);
 }

--- a/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationMenuItemRepository.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationMenuItemRepository.java
@@ -1,0 +1,7 @@
+package com.example.easybooking.reservation.domain.repository;
+
+import com.example.easybooking.reservation.domain.ReservationMenuItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationMenuItemRepository extends JpaRepository<ReservationMenuItem, Long> {
+}

--- a/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationMenuItemRepository.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/repository/ReservationMenuItemRepository.java
@@ -1,7 +1,10 @@
 package com.example.easybooking.reservation.domain.repository;
 
 import com.example.easybooking.reservation.domain.ReservationMenuItem;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReservationMenuItemRepository extends JpaRepository<ReservationMenuItem, Long> {
+
+    List<ReservationMenuItem> findByReservationIdOrderBySortOrderAsc(Long reservationId);
 }

--- a/src/main/java/com/example/easybooking/reservation/dto/MenuInputValueRequest.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/MenuInputValueRequest.java
@@ -1,0 +1,13 @@
+package com.example.easybooking.reservation.dto;
+
+import java.math.BigDecimal;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MenuInputValueRequest {
+    private final Long fieldId;
+    private final BigDecimal valueNumber;
+    private final String valueText;
+}

--- a/src/main/java/com/example/easybooking/reservation/dto/MenuSelectionRequest.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/MenuSelectionRequest.java
@@ -1,0 +1,16 @@
+package com.example.easybooking.reservation.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MenuSelectionRequest {
+    private Long menuId;
+    private List<MenuInputValueRequest> inputValues;
+}

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationCreateRequest.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationCreateRequest.java
@@ -1,26 +1,17 @@
 package com.example.easybooking.reservation.dto;
 
-import lombok.Data;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.util.List;
 import java.util.Map;
-
-// 고객이 입력하는 모든 예약 정보를 담음
-// 날짜, 시간, 샵 ID, 사진 URL 등
+import lombok.Data;
 
 @Data
 public class ReservationCreateRequest {
     private Long shopId;
     private Long staffId;
-    // private LocalDate date;
-    // private LocalTime time;
-    // private String designImageURL;
 
-    // 추가로 필요한 정보 ?
-    // 메모, 고객 전화번호 등
-    // private String name;         // 고객 이름
-    // private String phoneNumber;  // 고객 전화번호
-
-    // 폼 데이터 필드 추가
+    // 레거시 폼 데이터 (dual-write 호환)
     private Map<String, String> formData;
+
+    // 신규: 메뉴 선택 (nullable — 없으면 레거시 모드)
+    private List<MenuSelectionRequest> menuSelections;
 }

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationDetailResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationDetailResponse.java
@@ -38,5 +38,7 @@ public class ReservationDetailResponse {
 
     private String extendStatus;
     private String wrappingStatus;
+
+    private List<ReservationMenuItemResponse> menus;
 }
 

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationMenuInputValueResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationMenuInputValueResponse.java
@@ -1,0 +1,14 @@
+package com.example.easybooking.reservation.dto;
+
+import java.math.BigDecimal;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReservationMenuInputValueResponse {
+    private final String fieldLabelSnapshot;
+    private final String inputTypeSnapshot;
+    private final BigDecimal valueNumber;
+    private final String valueText;
+}

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationMenuItemResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationMenuItemResponse.java
@@ -1,0 +1,15 @@
+package com.example.easybooking.reservation.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReservationMenuItemResponse {
+    private final Long shopMenuId;
+    private final String menuNameSnapshot;
+    private final Long priceSnapshot;
+    private final Integer sortOrder;
+    private final List<ReservationMenuInputValueResponse> inputValues;
+}

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationMenuInputValueService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationMenuInputValueService.java
@@ -1,0 +1,128 @@
+package com.example.easybooking.reservation.service;
+
+import com.example.easybooking.reservation.ReservationMenuInputValueWriter;
+import com.example.easybooking.reservation.domain.ReservationMenuInputValue;
+import com.example.easybooking.reservation.dto.MenuInputValueRequest;
+import com.example.easybooking.shop.ShopMenuInputFieldReader;
+import com.example.easybooking.shop.domain.InputType;
+import com.example.easybooking.shop.domain.ShopMenuInputField;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationMenuInputValueService {
+
+    private final ShopMenuInputFieldReader inputFieldReader;
+    private final ReservationMenuInputValueWriter inputValueWriter;
+
+    public List<ReservationMenuInputValue> saveInputValues(Long reservationMenuItemId,
+                                                           Long shopMenuId,
+                                                           List<MenuInputValueRequest> requests) {
+        List<ShopMenuInputField> activeFields = inputFieldReader.findActiveByMenuId(shopMenuId);
+        Map<Long, ShopMenuInputField> fieldMap = activeFields.stream()
+                .collect(Collectors.toMap(ShopMenuInputField::getId, f -> f));
+
+        Set<Long> activeFieldIds = fieldMap.keySet();
+
+        // 제출된 fieldId가 해당 메뉴에 정의된 것인지 검증
+        if (requests != null) {
+            for (MenuInputValueRequest req : requests) {
+                if (!activeFieldIds.contains(req.getFieldId())) {
+                    throw new IllegalArgumentException(
+                            "fieldId=" + req.getFieldId() + "는 해당 메뉴에 정의되지 않은 입력 필드입니다.");
+                }
+            }
+        }
+
+        Map<Long, MenuInputValueRequest> requestMap = (requests == null ? List.<MenuInputValueRequest>of() : requests)
+                .stream()
+                .collect(Collectors.toMap(MenuInputValueRequest::getFieldId, r -> r));
+
+        List<ReservationMenuInputValue> values = new ArrayList<>();
+
+        for (ShopMenuInputField field : activeFields) {
+            MenuInputValueRequest req = requestMap.get(field.getId());
+
+            // required 필드 누락 검증
+            if (field.getRequired() && req == null) {
+                throw new IllegalArgumentException(
+                        "필수 입력 필드 '" + field.getLabel() + "'의 값이 누락되었습니다.");
+            }
+
+            if (req == null) {
+                continue;
+            }
+
+            validateFieldValue(field, req);
+
+            values.add(ReservationMenuInputValue.create(
+                    reservationMenuItemId,
+                    field.getId(),
+                    field.getLabel(),
+                    field.getInputType().name(),
+                    req.getValueNumber(),
+                    req.getValueText()
+            ));
+        }
+
+        return inputValueWriter.saveAll(values);
+    }
+
+    private void validateFieldValue(ShopMenuInputField field, MenuInputValueRequest req) {
+        if (field.getInputType() == InputType.NUMBER) {
+            if (req.getValueNumber() == null && req.getValueText() != null) {
+                throw new IllegalArgumentException(
+                        "NUMBER 타입 필드 '" + field.getLabel() + "'에 숫자 값이 필요합니다.");
+            }
+            if (req.getValueNumber() != null) {
+                validateNumberRange(field, req.getValueNumber());
+                validateNumberStep(field, req.getValueNumber());
+            }
+        } else if (field.getInputType() == InputType.TEXT) {
+            if (req.getValueText() == null && req.getValueNumber() != null) {
+                throw new IllegalArgumentException(
+                        "TEXT 타입 필드 '" + field.getLabel() + "'에 텍스트 값이 필요합니다.");
+            }
+            if (req.getValueText() != null) {
+                validateTextLength(field, req.getValueText());
+            }
+        }
+    }
+
+    private void validateNumberRange(ShopMenuInputField field, BigDecimal value) {
+        if (field.getMinValue() != null && value.compareTo(field.getMinValue()) < 0) {
+            throw new IllegalArgumentException(
+                    "필드 '" + field.getLabel() + "' 값이 최솟값(" + field.getMinValue() + ") 미만입니다.");
+        }
+        if (field.getMaxValue() != null && value.compareTo(field.getMaxValue()) > 0) {
+            throw new IllegalArgumentException(
+                    "필드 '" + field.getLabel() + "' 값이 최댓값(" + field.getMaxValue() + ")을 초과합니다.");
+        }
+    }
+
+    private void validateNumberStep(ShopMenuInputField field, BigDecimal value) {
+        if (field.getStepValue() == null) {
+            return;
+        }
+        BigDecimal base = field.getMinValue() != null ? field.getMinValue() : BigDecimal.ZERO;
+        BigDecimal diff = value.subtract(base);
+        if (diff.remainder(field.getStepValue()).compareTo(BigDecimal.ZERO) != 0) {
+            throw new IllegalArgumentException(
+                    "필드 '" + field.getLabel() + "' 값이 step(" + field.getStepValue() + ") 단위에 맞지 않습니다.");
+        }
+    }
+
+    private void validateTextLength(ShopMenuInputField field, String text) {
+        if (field.getMaxLength() != null && text.length() > field.getMaxLength()) {
+            throw new IllegalArgumentException(
+                    "필드 '" + field.getLabel() + "' 텍스트가 최대 길이(" + field.getMaxLength() + ")를 초과합니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationMenuItemService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationMenuItemService.java
@@ -1,0 +1,52 @@
+package com.example.easybooking.reservation.service;
+
+import com.example.easybooking.reservation.ReservationMenuItemWriter;
+import com.example.easybooking.reservation.domain.ReservationMenuItem;
+import com.example.easybooking.shop.ShopMenuReader;
+import com.example.easybooking.shop.domain.ShopMenu;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationMenuItemService {
+
+    private final ShopMenuReader shopMenuReader;
+    private final ReservationMenuItemWriter reservationMenuItemWriter;
+
+    public List<ReservationMenuItem> saveMenuItems(Long reservationId, Long shopId, List<Long> menuIds) {
+        if (menuIds == null || menuIds.isEmpty()) {
+            throw new IllegalArgumentException("메뉴를 최소 1개 이상 선택해야 합니다.");
+        }
+
+        AtomicInteger sortOrder = new AtomicInteger(0);
+
+        List<ReservationMenuItem> items = menuIds.stream()
+                .map(menuId -> {
+                    ShopMenu menu = shopMenuReader.getById(menuId);
+
+                    if (!menu.getShopId().equals(shopId)) {
+                        throw new IllegalArgumentException(
+                                "메뉴(id=" + menuId + ")가 해당 매장(shopId=" + shopId + ")에 속하지 않습니다.");
+                    }
+
+                    if (!menu.getIsActive()) {
+                        throw new IllegalArgumentException(
+                                "비활성 메뉴(id=" + menuId + ")는 선택할 수 없습니다.");
+                    }
+
+                    return ReservationMenuItem.create(
+                            reservationId,
+                            menuId,
+                            menu.getName(),
+                            null,
+                            sortOrder.getAndIncrement()
+                    );
+                })
+                .toList();
+
+        return reservationMenuItemWriter.saveAll(items);
+    }
+}

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -11,7 +11,9 @@ import com.example.easybooking.reservation.ReservationTimeBlockWriter;
 import com.example.easybooking.reservation.ReservationWriter;
 import com.example.easybooking.reservation.TimeBlockGenerator;
 import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.reservation.domain.ReservationMenuItem;
 import com.example.easybooking.reservation.domain.ReservationTimeBlock;
+import com.example.easybooking.reservation.dto.MenuSelectionRequest;
 import com.example.easybooking.reservation.dto.ReservationAvailabilityResponse;
 import com.example.easybooking.reservation.dto.ReservationConfirmRequest;
 import com.example.easybooking.reservation.dto.ReservationCreateRequest;
@@ -64,6 +66,8 @@ public class ReservationService {
     private final ApplicationEventPublisher eventPublisher;
     private final TimeBlockGenerator timeBlockGenerator;
     private final ReservationTimeBlockWriter reservationTimeBlockWriter;
+    private final ReservationMenuItemService reservationMenuItemService;
+    private final ReservationMenuInputValueService reservationMenuInputValueService;
 
 
     /**
@@ -176,6 +180,29 @@ public class ReservationService {
         newReservation.setStaffId(staffId);
 
         Reservation savedReservation = reservationWriter.save(newReservation);
+
+        // Dual-write: 메뉴 선택이 있으면 새 테이블에도 저장
+        List<MenuSelectionRequest> menuSelections = request.getMenuSelections();
+        if (menuSelections != null && !menuSelections.isEmpty()) {
+            List<Long> menuIds = menuSelections.stream()
+                    .map(MenuSelectionRequest::getMenuId)
+                    .toList();
+
+            List<ReservationMenuItem> savedMenuItems = reservationMenuItemService.saveMenuItems(
+                    savedReservation.getId(), shopId, menuIds);
+
+            // 메뉴별 입력값 저장
+            for (int i = 0; i < menuSelections.size(); i++) {
+                MenuSelectionRequest selection = menuSelections.get(i);
+                if (selection.getInputValues() != null && !selection.getInputValues().isEmpty()) {
+                    reservationMenuInputValueService.saveInputValues(
+                            savedMenuItems.get(i).getId(),
+                            selection.getMenuId(),
+                            selection.getInputValues()
+                    );
+                }
+            }
+        }
 
         // 예약 생성 커밋 성공 후 시스템 메시지 발행(웹소켓) 처리를 트리거
         eventPublisher.publishEvent(new ReservationEvent(

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -6,11 +6,14 @@ import com.example.easybooking.errors.errorcode.ReservationErrorCode;
 import com.example.easybooking.errors.exception.AuthException;
 import com.example.easybooking.errors.exception.ReservationException;
 import com.example.easybooking.form.FormParsingUtil;
+import com.example.easybooking.reservation.ReservationMenuInputValueReader;
+import com.example.easybooking.reservation.ReservationMenuItemReader;
 import com.example.easybooking.reservation.ReservationReader;
 import com.example.easybooking.reservation.ReservationTimeBlockWriter;
 import com.example.easybooking.reservation.ReservationWriter;
 import com.example.easybooking.reservation.TimeBlockGenerator;
 import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.reservation.domain.ReservationMenuInputValue;
 import com.example.easybooking.reservation.domain.ReservationMenuItem;
 import com.example.easybooking.reservation.domain.ReservationTimeBlock;
 import com.example.easybooking.reservation.dto.MenuSelectionRequest;
@@ -19,6 +22,8 @@ import com.example.easybooking.reservation.dto.ReservationConfirmRequest;
 import com.example.easybooking.reservation.dto.ReservationCreateRequest;
 import com.example.easybooking.reservation.dto.ReservationCustomerResponse;
 import com.example.easybooking.reservation.dto.ReservationDetailResponse;
+import com.example.easybooking.reservation.dto.ReservationMenuInputValueResponse;
+import com.example.easybooking.reservation.dto.ReservationMenuItemResponse;
 import com.example.easybooking.reservation.dto.ReservationOwnerResponse;
 import com.example.easybooking.reservation.dto.ReservationRejectRequest;
 import com.example.easybooking.reservation.dto.ReservationResponse;
@@ -68,6 +73,8 @@ public class ReservationService {
     private final ReservationTimeBlockWriter reservationTimeBlockWriter;
     private final ReservationMenuItemService reservationMenuItemService;
     private final ReservationMenuInputValueService reservationMenuInputValueService;
+    private final ReservationMenuItemReader menuItemReader;
+    private final ReservationMenuInputValueReader inputValueReader;
 
 
     /**
@@ -372,6 +379,8 @@ public class ReservationService {
 
         List<String> photoUrls = reservation.getDesignImageURLs();
 
+        List<ReservationMenuItemResponse> menus = loadMenuResponses(reservationId);
+
         return ReservationDetailResponse.builder()
                 .id(reservation.getId())
                 .status(reservation.getStatus())
@@ -393,7 +402,47 @@ public class ReservationService {
                 .wrappingCount(wrappingCount)
                 .extendStatus(extendStatus)
                 .wrappingStatus(wrappingStatus)
+                .menus(menus)
                 .build();
+    }
+
+    private List<ReservationMenuItemResponse> loadMenuResponses(Long reservationId) {
+        List<ReservationMenuItem> menuItems = menuItemReader.findByReservationId(reservationId);
+        if (menuItems.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> menuItemIds = menuItems.stream()
+                .map(ReservationMenuItem::getId)
+                .toList();
+
+        List<ReservationMenuInputValue> allInputValues =
+                inputValueReader.findByReservationMenuItemIds(menuItemIds);
+
+        Map<Long, List<ReservationMenuInputValue>> inputValuesByMenuItemId = allInputValues.stream()
+                .collect(Collectors.groupingBy(ReservationMenuInputValue::getReservationMenuItemId));
+
+        return menuItems.stream()
+                .map(item -> {
+                    List<ReservationMenuInputValueResponse> inputValueResponses =
+                            inputValuesByMenuItemId.getOrDefault(item.getId(), List.of()).stream()
+                                    .map(iv -> ReservationMenuInputValueResponse.builder()
+                                            .fieldLabelSnapshot(iv.getFieldLabelSnapshot())
+                                            .inputTypeSnapshot(iv.getInputTypeSnapshot())
+                                            .valueNumber(iv.getValueNumber())
+                                            .valueText(iv.getValueText())
+                                            .build())
+                                    .toList();
+
+                    return ReservationMenuItemResponse.builder()
+                            .shopMenuId(item.getShopMenuId())
+                            .menuNameSnapshot(item.getMenuNameSnapshot())
+                            .priceSnapshot(item.getPriceSnapshot())
+                            .sortOrder(item.getSortOrder())
+                            .inputValues(inputValueResponses)
+                            .build();
+                })
+                .toList();
     }
 
     /**

--- a/src/main/java/com/example/easybooking/shop/ShopMenuInputFieldReader.java
+++ b/src/main/java/com/example/easybooking/shop/ShopMenuInputFieldReader.java
@@ -1,0 +1,23 @@
+package com.example.easybooking.shop;
+
+import com.example.easybooking.shop.domain.ShopMenuInputField;
+import com.example.easybooking.shop.repository.ShopMenuInputFieldRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ShopMenuInputFieldReader {
+
+    private final ShopMenuInputFieldRepository repository;
+
+    public List<ShopMenuInputField> findActiveByMenuId(Long shopMenuId) {
+        return repository.findByShopMenuIdAndIsActiveTrueOrderBySortOrderAsc(shopMenuId);
+    }
+
+    public ShopMenuInputField getById(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new RuntimeException("ShopMenuInputField not found: " + id));
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/ShopMenuInputFieldWriter.java
+++ b/src/main/java/com/example/easybooking/shop/ShopMenuInputFieldWriter.java
@@ -1,0 +1,17 @@
+package com.example.easybooking.shop;
+
+import com.example.easybooking.shop.domain.ShopMenuInputField;
+import com.example.easybooking.shop.repository.ShopMenuInputFieldRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ShopMenuInputFieldWriter {
+
+    private final ShopMenuInputFieldRepository repository;
+
+    public ShopMenuInputField save(ShopMenuInputField field) {
+        return repository.save(field);
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/ShopMenuReader.java
+++ b/src/main/java/com/example/easybooking/shop/ShopMenuReader.java
@@ -20,4 +20,8 @@ public class ShopMenuReader {
         return shopMenuRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("ShopMenu not found: " + id));
     }
+
+    public List<ShopMenu> findActiveByShopIdAndTagIds(Long shopId, List<Long> tagIds) {
+        return shopMenuRepository.findActiveByShopIdAndTagIds(shopId, tagIds);
+    }
 }

--- a/src/main/java/com/example/easybooking/shop/ShopMenuReader.java
+++ b/src/main/java/com/example/easybooking/shop/ShopMenuReader.java
@@ -1,0 +1,23 @@
+package com.example.easybooking.shop;
+
+import com.example.easybooking.shop.domain.ShopMenu;
+import com.example.easybooking.shop.repository.ShopMenuRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ShopMenuReader {
+
+    private final ShopMenuRepository shopMenuRepository;
+
+    public List<ShopMenu> findActiveByShopId(Long shopId) {
+        return shopMenuRepository.findByShopIdAndIsActiveTrueOrderBySortOrderAsc(shopId);
+    }
+
+    public ShopMenu getById(Long id) {
+        return shopMenuRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("ShopMenu not found: " + id));
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/ShopMenuWriter.java
+++ b/src/main/java/com/example/easybooking/shop/ShopMenuWriter.java
@@ -1,0 +1,17 @@
+package com.example.easybooking.shop;
+
+import com.example.easybooking.shop.domain.ShopMenu;
+import com.example.easybooking.shop.repository.ShopMenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ShopMenuWriter {
+
+    private final ShopMenuRepository shopMenuRepository;
+
+    public ShopMenu save(ShopMenu shopMenu) {
+        return shopMenuRepository.save(shopMenu);
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/domain/InputType.java
+++ b/src/main/java/com/example/easybooking/shop/domain/InputType.java
@@ -1,0 +1,6 @@
+package com.example.easybooking.shop.domain;
+
+public enum InputType {
+    NUMBER,
+    TEXT
+}

--- a/src/main/java/com/example/easybooking/shop/domain/ShopMenu.java
+++ b/src/main/java/com/example/easybooking/shop/domain/ShopMenu.java
@@ -1,0 +1,71 @@
+package com.example.easybooking.shop.domain;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "shop_menus",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_shop_menus_shop_name",
+                columnNames = {"shop_id", "name"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ShopMenu {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "shop_id", nullable = false)
+    private Long shopId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column
+    private String description;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public static ShopMenu create(Long shopId, String name, String description,
+                                  Boolean isActive, Integer sortOrder) {
+        ShopMenu menu = new ShopMenu();
+        menu.shopId = shopId;
+        menu.name = name;
+        menu.description = description;
+        menu.isActive = isActive;
+        menu.sortOrder = sortOrder;
+        return menu;
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/domain/ShopMenu.java
+++ b/src/main/java/com/example/easybooking/shop/domain/ShopMenu.java
@@ -68,4 +68,20 @@ public class ShopMenu {
         menu.sortOrder = sortOrder;
         return menu;
     }
+
+    public void update(String name, String description, Integer sortOrder) {
+        if (name != null) {
+            this.name = name;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (sortOrder != null) {
+            this.sortOrder = sortOrder;
+        }
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
 }

--- a/src/main/java/com/example/easybooking/shop/domain/ShopMenuInputField.java
+++ b/src/main/java/com/example/easybooking/shop/domain/ShopMenuInputField.java
@@ -1,0 +1,146 @@
+package com.example.easybooking.shop.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "shop_menu_input_fields",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_shop_menu_input_fields",
+                columnNames = {"shop_menu_id", "label"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ShopMenuInputField {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "shop_menu_id", nullable = false)
+    private Long shopMenuId;
+
+    @Column(nullable = false)
+    private String label;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "input_type", nullable = false, length = 20)
+    private InputType inputType;
+
+    @Column(nullable = false)
+    private Boolean required;
+
+    @Column(name = "min_value", precision = 10, scale = 2)
+    private BigDecimal minValue;
+
+    @Column(name = "max_value", precision = 10, scale = 2)
+    private BigDecimal maxValue;
+
+    @Column(name = "step_value", precision = 10, scale = 2)
+    private BigDecimal stepValue;
+
+    @Column(name = "max_length")
+    private Integer maxLength;
+
+    @Column(length = 255)
+    private String placeholder;
+
+    @Column(name = "sort_order", nullable = false)
+    private Integer sortOrder;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static ShopMenuInputField create(Long shopMenuId, String label, InputType inputType,
+                                            Boolean required, BigDecimal minValue, BigDecimal maxValue,
+                                            BigDecimal stepValue, Integer maxLength,
+                                            String placeholder, Integer sortOrder) {
+        ShopMenuInputField field = new ShopMenuInputField();
+        field.shopMenuId = shopMenuId;
+        field.label = label;
+        field.inputType = inputType;
+        field.required = required;
+        field.sortOrder = sortOrder;
+        field.placeholder = placeholder;
+        field.isActive = true;
+
+        // 타입별 필드 정합성: 관련 없는 필드는 무시
+        if (inputType == InputType.NUMBER) {
+            field.minValue = minValue;
+            field.maxValue = maxValue;
+            field.stepValue = stepValue;
+            field.maxLength = null;  // NUMBER에 maxLength 무시
+        } else {
+            field.minValue = null;   // TEXT에 min/max/step 무시
+            field.maxValue = null;
+            field.stepValue = null;
+            field.maxLength = maxLength;
+        }
+
+        field.validate();
+        return field;
+    }
+
+    public void update(String label, BigDecimal minValue, BigDecimal maxValue,
+                       BigDecimal stepValue, Integer maxLength, String placeholder, Integer sortOrder) {
+        if (label != null) this.label = label;
+        if (placeholder != null) this.placeholder = placeholder;
+        if (sortOrder != null) this.sortOrder = sortOrder;
+
+        if (this.inputType == InputType.NUMBER) {
+            if (minValue != null) this.minValue = minValue;
+            if (maxValue != null) this.maxValue = maxValue;
+            if (stepValue != null) this.stepValue = stepValue;
+        } else {
+            if (maxLength != null) this.maxLength = maxLength;
+        }
+
+        validate();
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+
+    private void validate() {
+        if (inputType == InputType.NUMBER) {
+            if (minValue != null && maxValue != null && minValue.compareTo(maxValue) > 0) {
+                throw new IllegalArgumentException("minValue must be <= maxValue");
+            }
+            if (stepValue != null && stepValue.compareTo(BigDecimal.ZERO) <= 0) {
+                throw new IllegalArgumentException("stepValue must be > 0");
+            }
+        }
+        if (inputType == InputType.TEXT) {
+            if (maxLength != null && maxLength <= 0) {
+                throw new IllegalArgumentException("maxLength must be > 0");
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/domain/ShopMenuTag.java
+++ b/src/main/java/com/example/easybooking/shop/domain/ShopMenuTag.java
@@ -1,0 +1,42 @@
+package com.example.easybooking.shop.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "shop_menu_tags",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_shop_menu_tags",
+                columnNames = {"shop_menu_id", "tag_id"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ShopMenuTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "shop_menu_id", nullable = false)
+    private Long shopMenuId;
+
+    @Column(name = "tag_id", nullable = false)
+    private Long tagId;
+
+    public static ShopMenuTag create(Long shopMenuId, Long tagId) {
+        ShopMenuTag tag = new ShopMenuTag();
+        tag.shopMenuId = shopMenuId;
+        tag.tagId = tagId;
+        return tag;
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/domain/Tag.java
+++ b/src/main/java/com/example/easybooking/shop/domain/Tag.java
@@ -1,0 +1,51 @@
+package com.example.easybooking.shop.domain;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "tags",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_tags_name",
+                columnNames = {"name"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public static Tag create(String name) {
+        Tag tag = new Tag();
+        tag.name = name;
+        return tag;
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/dto/request/AddTagToMenuRequest.java
+++ b/src/main/java/com/example/easybooking/shop/dto/request/AddTagToMenuRequest.java
@@ -1,0 +1,17 @@
+package com.example.easybooking.shop.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AddTagToMenuRequest {
+
+    @NotNull
+    private Long tagId;
+
+    public AddTagToMenuRequest(Long tagId) {
+        this.tagId = tagId;
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/dto/request/CreateInputFieldRequest.java
+++ b/src/main/java/com/example/easybooking/shop/dto/request/CreateInputFieldRequest.java
@@ -1,0 +1,42 @@
+package com.example.easybooking.shop.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateInputFieldRequest {
+
+    @NotBlank
+    private String label;
+
+    @NotNull
+    private String inputType;
+
+    @NotNull
+    private Boolean required;
+
+    private BigDecimal minValue;
+    private BigDecimal maxValue;
+    private BigDecimal stepValue;
+    private Integer maxLength;
+    private String placeholder;
+    private int sortOrder;
+
+    public CreateInputFieldRequest(String label, String inputType, Boolean required,
+                                   BigDecimal minValue, BigDecimal maxValue, BigDecimal stepValue,
+                                   Integer maxLength, String placeholder, int sortOrder) {
+        this.label = label;
+        this.inputType = inputType;
+        this.required = required;
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+        this.stepValue = stepValue;
+        this.maxLength = maxLength;
+        this.placeholder = placeholder;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/dto/request/CreateShopMenuRequest.java
+++ b/src/main/java/com/example/easybooking/shop/dto/request/CreateShopMenuRequest.java
@@ -1,0 +1,23 @@
+package com.example.easybooking.shop.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateShopMenuRequest {
+
+    @NotBlank
+    private String name;
+
+    private String description;
+
+    private int sortOrder;
+
+    public CreateShopMenuRequest(String name, String description, int sortOrder) {
+        this.name = name;
+        this.description = description;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/dto/request/CreateTagRequest.java
+++ b/src/main/java/com/example/easybooking/shop/dto/request/CreateTagRequest.java
@@ -1,0 +1,17 @@
+package com.example.easybooking.shop.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateTagRequest {
+
+    @NotBlank
+    private String name;
+
+    public CreateTagRequest(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/dto/request/UpdateInputFieldRequest.java
+++ b/src/main/java/com/example/easybooking/shop/dto/request/UpdateInputFieldRequest.java
@@ -1,0 +1,30 @@
+package com.example.easybooking.shop.dto.request;
+
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateInputFieldRequest {
+
+    private String label;
+    private BigDecimal minValue;
+    private BigDecimal maxValue;
+    private BigDecimal stepValue;
+    private Integer maxLength;
+    private String placeholder;
+    private Integer sortOrder;
+
+    public UpdateInputFieldRequest(String label, BigDecimal minValue, BigDecimal maxValue,
+                                   BigDecimal stepValue, Integer maxLength, String placeholder,
+                                   Integer sortOrder) {
+        this.label = label;
+        this.minValue = minValue;
+        this.maxValue = maxValue;
+        this.stepValue = stepValue;
+        this.maxLength = maxLength;
+        this.placeholder = placeholder;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/dto/request/UpdateShopMenuRequest.java
+++ b/src/main/java/com/example/easybooking/shop/dto/request/UpdateShopMenuRequest.java
@@ -1,0 +1,21 @@
+package com.example.easybooking.shop.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateShopMenuRequest {
+
+    private String name;
+
+    private String description;
+
+    private Integer sortOrder;
+
+    public UpdateShopMenuRequest(String name, String description, Integer sortOrder) {
+        this.name = name;
+        this.description = description;
+        this.sortOrder = sortOrder;
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/dto/response/InputFieldResponse.java
+++ b/src/main/java/com/example/easybooking/shop/dto/response/InputFieldResponse.java
@@ -1,0 +1,37 @@
+package com.example.easybooking.shop.dto.response;
+
+import com.example.easybooking.shop.domain.ShopMenuInputField;
+import java.math.BigDecimal;
+import lombok.Getter;
+
+@Getter
+public class InputFieldResponse {
+
+    private final Long id;
+    private final Long shopMenuId;
+    private final String label;
+    private final String inputType;
+    private final Boolean required;
+    private final BigDecimal minValue;
+    private final BigDecimal maxValue;
+    private final BigDecimal stepValue;
+    private final Integer maxLength;
+    private final String placeholder;
+    private final Integer sortOrder;
+    private final Boolean isActive;
+
+    public InputFieldResponse(ShopMenuInputField field) {
+        this.id = field.getId();
+        this.shopMenuId = field.getShopMenuId();
+        this.label = field.getLabel();
+        this.inputType = field.getInputType().name();
+        this.required = field.getRequired();
+        this.minValue = field.getMinValue();
+        this.maxValue = field.getMaxValue();
+        this.stepValue = field.getStepValue();
+        this.maxLength = field.getMaxLength();
+        this.placeholder = field.getPlaceholder();
+        this.sortOrder = field.getSortOrder();
+        this.isActive = field.getIsActive();
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/dto/response/ShopMenuResponse.java
+++ b/src/main/java/com/example/easybooking/shop/dto/response/ShopMenuResponse.java
@@ -1,0 +1,24 @@
+package com.example.easybooking.shop.dto.response;
+
+import com.example.easybooking.shop.domain.ShopMenu;
+import lombok.Getter;
+
+@Getter
+public class ShopMenuResponse {
+
+    private final Long id;
+    private final Long shopId;
+    private final String name;
+    private final String description;
+    private final Boolean isActive;
+    private final Integer sortOrder;
+
+    public ShopMenuResponse(ShopMenu menu) {
+        this.id = menu.getId();
+        this.shopId = menu.getShopId();
+        this.name = menu.getName();
+        this.description = menu.getDescription();
+        this.isActive = menu.getIsActive();
+        this.sortOrder = menu.getSortOrder();
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/dto/response/TagResponse.java
+++ b/src/main/java/com/example/easybooking/shop/dto/response/TagResponse.java
@@ -1,0 +1,16 @@
+package com.example.easybooking.shop.dto.response;
+
+import com.example.easybooking.shop.domain.Tag;
+import lombok.Getter;
+
+@Getter
+public class TagResponse {
+
+    private final Long id;
+    private final String name;
+
+    public TagResponse(Tag tag) {
+        this.id = tag.getId();
+        this.name = tag.getName();
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/presentation/ShopMenuController.java
+++ b/src/main/java/com/example/easybooking/shop/presentation/ShopMenuController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,8 +35,10 @@ public class ShopMenuController {
     }
 
     @GetMapping
-    public ResponseEntity<List<ShopMenuResponse>> getMenus(@PathVariable Long shopId) {
-        return ResponseEntity.ok(shopMenuManagementService.getActiveMenus(shopId));
+    public ResponseEntity<List<ShopMenuResponse>> getMenus(
+            @PathVariable Long shopId,
+            @RequestParam(required = false) List<Long> tagIds) {
+        return ResponseEntity.ok(shopMenuManagementService.getActiveMenus(shopId, tagIds));
     }
 
     @PatchMapping("/{menuId}")

--- a/src/main/java/com/example/easybooking/shop/presentation/ShopMenuController.java
+++ b/src/main/java/com/example/easybooking/shop/presentation/ShopMenuController.java
@@ -1,0 +1,56 @@
+package com.example.easybooking.shop.presentation;
+
+import com.example.easybooking.shop.dto.request.CreateShopMenuRequest;
+import com.example.easybooking.shop.dto.request.UpdateShopMenuRequest;
+import com.example.easybooking.shop.dto.response.ShopMenuResponse;
+import com.example.easybooking.shop.service.ShopMenuManagementService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/shops/{shopId}/menus")
+public class ShopMenuController {
+
+    private final ShopMenuManagementService shopMenuManagementService;
+
+    @PostMapping
+    public ResponseEntity<ShopMenuResponse> create(
+            @PathVariable Long shopId,
+            @Valid @RequestBody CreateShopMenuRequest request) {
+        ShopMenuResponse response = shopMenuManagementService.create(shopId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ShopMenuResponse>> getMenus(@PathVariable Long shopId) {
+        return ResponseEntity.ok(shopMenuManagementService.getActiveMenus(shopId));
+    }
+
+    @PatchMapping("/{menuId}")
+    public ResponseEntity<ShopMenuResponse> update(
+            @PathVariable Long shopId,
+            @PathVariable Long menuId,
+            @RequestBody UpdateShopMenuRequest request) {
+        return ResponseEntity.ok(shopMenuManagementService.update(shopId, menuId, request));
+    }
+
+    @DeleteMapping("/{menuId}")
+    public ResponseEntity<Void> deactivate(
+            @PathVariable Long shopId,
+            @PathVariable Long menuId) {
+        shopMenuManagementService.deactivate(shopId, menuId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/presentation/ShopMenuInputFieldController.java
+++ b/src/main/java/com/example/easybooking/shop/presentation/ShopMenuInputFieldController.java
@@ -1,0 +1,60 @@
+package com.example.easybooking.shop.presentation;
+
+import com.example.easybooking.shop.dto.request.CreateInputFieldRequest;
+import com.example.easybooking.shop.dto.request.UpdateInputFieldRequest;
+import com.example.easybooking.shop.dto.response.InputFieldResponse;
+import com.example.easybooking.shop.service.ShopMenuInputFieldService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/shops/{shopId}/menus/{menuId}/input-fields")
+public class ShopMenuInputFieldController {
+
+    private final ShopMenuInputFieldService inputFieldService;
+
+    @PostMapping
+    public ResponseEntity<InputFieldResponse> create(
+            @PathVariable Long shopId,
+            @PathVariable Long menuId,
+            @Valid @RequestBody CreateInputFieldRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(inputFieldService.create(menuId, request));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<InputFieldResponse>> getFields(
+            @PathVariable Long shopId,
+            @PathVariable Long menuId) {
+        return ResponseEntity.ok(inputFieldService.getActiveFields(menuId));
+    }
+
+    @PatchMapping("/{fieldId}")
+    public ResponseEntity<InputFieldResponse> update(
+            @PathVariable Long shopId,
+            @PathVariable Long menuId,
+            @PathVariable Long fieldId,
+            @RequestBody UpdateInputFieldRequest request) {
+        return ResponseEntity.ok(inputFieldService.update(fieldId, request));
+    }
+
+    @DeleteMapping("/{fieldId}")
+    public ResponseEntity<Void> deactivate(
+            @PathVariable Long shopId,
+            @PathVariable Long menuId,
+            @PathVariable Long fieldId) {
+        inputFieldService.deactivate(fieldId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/presentation/TagController.java
+++ b/src/main/java/com/example/easybooking/shop/presentation/TagController.java
@@ -1,0 +1,52 @@
+package com.example.easybooking.shop.presentation;
+
+import com.example.easybooking.shop.dto.request.AddTagToMenuRequest;
+import com.example.easybooking.shop.dto.request.CreateTagRequest;
+import com.example.easybooking.shop.dto.response.TagResponse;
+import com.example.easybooking.shop.service.TagService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TagController {
+
+    private final TagService tagService;
+
+    @PostMapping("/api/tags")
+    public ResponseEntity<TagResponse> createTag(@Valid @RequestBody CreateTagRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(tagService.createOrGet(request.getName()));
+    }
+
+    @GetMapping("/api/tags")
+    public ResponseEntity<List<TagResponse>> getAllTags() {
+        return ResponseEntity.ok(tagService.getAllTags());
+    }
+
+    @PostMapping("/api/shops/{shopId}/menus/{menuId}/tags")
+    public ResponseEntity<Void> addTagToMenu(
+            @PathVariable Long shopId,
+            @PathVariable Long menuId,
+            @Valid @RequestBody AddTagToMenuRequest request) {
+        tagService.addTagToMenu(menuId, request.getTagId());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/api/shops/{shopId}/menus/{menuId}/tags/{tagId}")
+    public ResponseEntity<Void> removeTagFromMenu(
+            @PathVariable Long shopId,
+            @PathVariable Long menuId,
+            @PathVariable Long tagId) {
+        tagService.removeTagFromMenu(menuId, tagId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/repository/ShopMenuInputFieldRepository.java
+++ b/src/main/java/com/example/easybooking/shop/repository/ShopMenuInputFieldRepository.java
@@ -1,0 +1,10 @@
+package com.example.easybooking.shop.repository;
+
+import com.example.easybooking.shop.domain.ShopMenuInputField;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopMenuInputFieldRepository extends JpaRepository<ShopMenuInputField, Long> {
+
+    List<ShopMenuInputField> findByShopMenuIdAndIsActiveTrueOrderBySortOrderAsc(Long shopMenuId);
+}

--- a/src/main/java/com/example/easybooking/shop/repository/ShopMenuRepository.java
+++ b/src/main/java/com/example/easybooking/shop/repository/ShopMenuRepository.java
@@ -1,0 +1,7 @@
+package com.example.easybooking.shop.repository;
+
+import com.example.easybooking.shop.domain.ShopMenu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopMenuRepository extends JpaRepository<ShopMenu, Long> {
+}

--- a/src/main/java/com/example/easybooking/shop/repository/ShopMenuRepository.java
+++ b/src/main/java/com/example/easybooking/shop/repository/ShopMenuRepository.java
@@ -3,8 +3,16 @@ package com.example.easybooking.shop.repository;
 import com.example.easybooking.shop.domain.ShopMenu;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ShopMenuRepository extends JpaRepository<ShopMenu, Long> {
 
     List<ShopMenu> findByShopIdAndIsActiveTrueOrderBySortOrderAsc(Long shopId);
+
+    @Query("SELECT DISTINCT m FROM ShopMenu m JOIN ShopMenuTag smt ON m.id = smt.shopMenuId "
+            + "WHERE m.shopId = :shopId AND m.isActive = true AND smt.tagId IN :tagIds "
+            + "ORDER BY m.sortOrder ASC")
+    List<ShopMenu> findActiveByShopIdAndTagIds(@Param("shopId") Long shopId,
+                                               @Param("tagIds") List<Long> tagIds);
 }

--- a/src/main/java/com/example/easybooking/shop/repository/ShopMenuRepository.java
+++ b/src/main/java/com/example/easybooking/shop/repository/ShopMenuRepository.java
@@ -1,7 +1,10 @@
 package com.example.easybooking.shop.repository;
 
 import com.example.easybooking.shop.domain.ShopMenu;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ShopMenuRepository extends JpaRepository<ShopMenu, Long> {
+
+    List<ShopMenu> findByShopIdAndIsActiveTrueOrderBySortOrderAsc(Long shopId);
 }

--- a/src/main/java/com/example/easybooking/shop/repository/ShopMenuTagRepository.java
+++ b/src/main/java/com/example/easybooking/shop/repository/ShopMenuTagRepository.java
@@ -1,0 +1,12 @@
+package com.example.easybooking.shop.repository;
+
+import com.example.easybooking.shop.domain.ShopMenuTag;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShopMenuTagRepository extends JpaRepository<ShopMenuTag, Long> {
+
+    Optional<ShopMenuTag> findByShopMenuIdAndTagId(Long shopMenuId, Long tagId);
+
+    void deleteByShopMenuIdAndTagId(Long shopMenuId, Long tagId);
+}

--- a/src/main/java/com/example/easybooking/shop/repository/TagRepository.java
+++ b/src/main/java/com/example/easybooking/shop/repository/TagRepository.java
@@ -1,0 +1,10 @@
+package com.example.easybooking.shop.repository;
+
+import com.example.easybooking.shop.domain.Tag;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    Optional<Tag> findByName(String name);
+}

--- a/src/main/java/com/example/easybooking/shop/service/ShopMenuInputFieldService.java
+++ b/src/main/java/com/example/easybooking/shop/service/ShopMenuInputFieldService.java
@@ -1,0 +1,53 @@
+package com.example.easybooking.shop.service;
+
+import com.example.easybooking.shop.ShopMenuInputFieldReader;
+import com.example.easybooking.shop.ShopMenuInputFieldWriter;
+import com.example.easybooking.shop.domain.InputType;
+import com.example.easybooking.shop.domain.ShopMenuInputField;
+import com.example.easybooking.shop.dto.request.CreateInputFieldRequest;
+import com.example.easybooking.shop.dto.request.UpdateInputFieldRequest;
+import com.example.easybooking.shop.dto.response.InputFieldResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ShopMenuInputFieldService {
+
+    private final ShopMenuInputFieldReader reader;
+    private final ShopMenuInputFieldWriter writer;
+
+    @Transactional
+    public InputFieldResponse create(Long menuId, CreateInputFieldRequest request) {
+        InputType type = InputType.valueOf(request.getInputType());
+        ShopMenuInputField field = ShopMenuInputField.create(
+                menuId, request.getLabel(), type, request.getRequired(),
+                request.getMinValue(), request.getMaxValue(), request.getStepValue(),
+                request.getMaxLength(), request.getPlaceholder(), request.getSortOrder());
+        return new InputFieldResponse(writer.save(field));
+    }
+
+    public List<InputFieldResponse> getActiveFields(Long menuId) {
+        return reader.findActiveByMenuId(menuId).stream()
+                .map(InputFieldResponse::new)
+                .toList();
+    }
+
+    @Transactional
+    public InputFieldResponse update(Long fieldId, UpdateInputFieldRequest request) {
+        ShopMenuInputField field = reader.getById(fieldId);
+        field.update(request.getLabel(), request.getMinValue(), request.getMaxValue(),
+                request.getStepValue(), request.getMaxLength(), request.getPlaceholder(),
+                request.getSortOrder());
+        return new InputFieldResponse(field);
+    }
+
+    @Transactional
+    public void deactivate(Long fieldId) {
+        ShopMenuInputField field = reader.getById(fieldId);
+        field.deactivate();
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/service/ShopMenuManagementService.java
+++ b/src/main/java/com/example/easybooking/shop/service/ShopMenuManagementService.java
@@ -1,0 +1,48 @@
+package com.example.easybooking.shop.service;
+
+import com.example.easybooking.shop.ShopMenuReader;
+import com.example.easybooking.shop.ShopMenuWriter;
+import com.example.easybooking.shop.domain.ShopMenu;
+import com.example.easybooking.shop.dto.request.CreateShopMenuRequest;
+import com.example.easybooking.shop.dto.request.UpdateShopMenuRequest;
+import com.example.easybooking.shop.dto.response.ShopMenuResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ShopMenuManagementService {
+
+    private final ShopMenuReader shopMenuReader;
+    private final ShopMenuWriter shopMenuWriter;
+
+    @Transactional
+    public ShopMenuResponse create(Long shopId, CreateShopMenuRequest request) {
+        ShopMenu menu = ShopMenu.create(shopId, request.getName(), request.getDescription(),
+                true, request.getSortOrder());
+        ShopMenu saved = shopMenuWriter.save(menu);
+        return new ShopMenuResponse(saved);
+    }
+
+    public List<ShopMenuResponse> getActiveMenus(Long shopId) {
+        return shopMenuReader.findActiveByShopId(shopId).stream()
+                .map(ShopMenuResponse::new)
+                .toList();
+    }
+
+    @Transactional
+    public ShopMenuResponse update(Long shopId, Long menuId, UpdateShopMenuRequest request) {
+        ShopMenu menu = shopMenuReader.getById(menuId);
+        menu.update(request.getName(), request.getDescription(), request.getSortOrder());
+        return new ShopMenuResponse(menu);
+    }
+
+    @Transactional
+    public void deactivate(Long shopId, Long menuId) {
+        ShopMenu menu = shopMenuReader.getById(menuId);
+        menu.deactivate();
+    }
+}

--- a/src/main/java/com/example/easybooking/shop/service/ShopMenuManagementService.java
+++ b/src/main/java/com/example/easybooking/shop/service/ShopMenuManagementService.java
@@ -27,8 +27,14 @@ public class ShopMenuManagementService {
         return new ShopMenuResponse(saved);
     }
 
-    public List<ShopMenuResponse> getActiveMenus(Long shopId) {
-        return shopMenuReader.findActiveByShopId(shopId).stream()
+    public List<ShopMenuResponse> getActiveMenus(Long shopId, List<Long> tagIds) {
+        List<ShopMenu> menus;
+        if (tagIds == null || tagIds.isEmpty()) {
+            menus = shopMenuReader.findActiveByShopId(shopId);
+        } else {
+            menus = shopMenuReader.findActiveByShopIdAndTagIds(shopId, tagIds);
+        }
+        return menus.stream()
                 .map(ShopMenuResponse::new)
                 .toList();
     }

--- a/src/main/java/com/example/easybooking/shop/service/TagService.java
+++ b/src/main/java/com/example/easybooking/shop/service/TagService.java
@@ -1,0 +1,43 @@
+package com.example.easybooking.shop.service;
+
+import com.example.easybooking.shop.domain.ShopMenuTag;
+import com.example.easybooking.shop.domain.Tag;
+import com.example.easybooking.shop.dto.response.TagResponse;
+import com.example.easybooking.shop.repository.ShopMenuTagRepository;
+import com.example.easybooking.shop.repository.TagRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TagService {
+
+    private final TagRepository tagRepository;
+    private final ShopMenuTagRepository shopMenuTagRepository;
+
+    @Transactional
+    public TagResponse createOrGet(String name) {
+        Tag tag = tagRepository.findByName(name)
+                .orElseGet(() -> tagRepository.save(Tag.create(name)));
+        return new TagResponse(tag);
+    }
+
+    public List<TagResponse> getAllTags() {
+        return tagRepository.findAll().stream()
+                .map(TagResponse::new)
+                .toList();
+    }
+
+    @Transactional
+    public void addTagToMenu(Long menuId, Long tagId) {
+        shopMenuTagRepository.save(ShopMenuTag.create(menuId, tagId));
+    }
+
+    @Transactional
+    public void removeTagFromMenu(Long menuId, Long tagId) {
+        shopMenuTagRepository.deleteByShopMenuIdAndTagId(menuId, tagId);
+    }
+}

--- a/src/main/resources/db/migration/V4__rename_shop_services_to_shop_menus.sql
+++ b/src/main/resources/db/migration/V4__rename_shop_services_to_shop_menus.sql
@@ -1,0 +1,145 @@
+-- #99 shop_services 계열 → shop_menus 계열 리네이밍 + key 컬럼 제거
+-- Created: 2026-02-10
+-- 대상 테이블: shop_services, shop_service_tags, shop_service_input_fields, reservation_services
+-- 추가: key 컬럼 제거, field_key_snapshot 컬럼 제거, UNIQUE(shop_menu_id, label) 추가
+-- 전제: 위 테이블에 데이터 없음 (기존 테이블 데이터는 영향 없음)
+
+-- ============================================================
+-- 1) FK 제약 DROP (V3에서 추가한 것들)
+-- ============================================================
+ALTER TABLE reservation_services DROP FOREIGN KEY fk_res_services_reservation;
+ALTER TABLE reservation_services DROP FOREIGN KEY fk_res_services_shop_service;
+ALTER TABLE reservation_menu_input_values DROP FOREIGN KEY fk_rmiv_res_service;
+ALTER TABLE reservation_menu_input_values DROP FOREIGN KEY fk_rmiv_input_field;
+ALTER TABLE shop_service_tags DROP FOREIGN KEY fk_sst_shop_service;
+ALTER TABLE shop_service_tags DROP FOREIGN KEY fk_sst_tag;
+
+-- ============================================================
+-- 2) UNIQUE 제약 DROP (V1 CREATE TABLE + V3 ALTER TABLE)
+-- ============================================================
+-- shop_services
+ALTER TABLE shop_services DROP INDEX uq_shop_services_shop_name;
+
+-- shop_service_tags
+ALTER TABLE shop_service_tags DROP INDEX uq_shop_service_tags;
+
+-- shop_service_input_fields
+ALTER TABLE shop_service_input_fields DROP INDEX uq_shop_service_input_fields;
+
+-- reservation_services (V3)
+ALTER TABLE reservation_services DROP INDEX uq_reservation_services_res_shop_service;
+
+-- reservation_menu_input_values (V3)
+ALTER TABLE reservation_menu_input_values DROP INDEX uq_res_menu_input_values;
+
+-- ============================================================
+-- 3) INDEX DROP (V1 CREATE TABLE)
+-- ============================================================
+-- shop_services
+ALTER TABLE shop_services DROP INDEX idx_shop_services_shop_active_sort;
+
+-- shop_service_tags
+ALTER TABLE shop_service_tags DROP INDEX idx_shop_service_tags_tag;
+
+-- shop_service_input_fields
+ALTER TABLE shop_service_input_fields DROP INDEX idx_shop_service_input_fields_service;
+
+-- reservation_services
+ALTER TABLE reservation_services DROP INDEX idx_reservation_services_reservation;
+ALTER TABLE reservation_services DROP INDEX idx_reservation_services_shop_service;
+
+-- reservation_menu_input_values
+ALTER TABLE reservation_menu_input_values DROP INDEX idx_res_menu_input_values_res_service;
+
+-- ============================================================
+-- 4) RENAME TABLE (4개)
+-- ============================================================
+RENAME TABLE shop_services TO shop_menus;
+RENAME TABLE shop_service_tags TO shop_menu_tags;
+RENAME TABLE shop_service_input_fields TO shop_menu_input_fields;
+RENAME TABLE reservation_services TO reservation_menu_items;
+
+-- ============================================================
+-- 5) RENAME COLUMN (8개)
+-- ============================================================
+-- shop_menu_tags
+ALTER TABLE shop_menu_tags RENAME COLUMN shop_service_id TO shop_menu_id;
+
+-- shop_menu_input_fields
+ALTER TABLE shop_menu_input_fields RENAME COLUMN shop_service_id TO shop_menu_id;
+
+-- reservation_menu_items (3개: FK + 스냅샷 3개)
+ALTER TABLE reservation_menu_items RENAME COLUMN shop_service_id TO shop_menu_id;
+ALTER TABLE reservation_menu_items RENAME COLUMN service_name_snapshot TO menu_name_snapshot;
+ALTER TABLE reservation_menu_items RENAME COLUMN service_description_snapshot TO menu_description_snapshot;
+ALTER TABLE reservation_menu_items RENAME COLUMN service_duration_snapshot_minutes TO menu_duration_snapshot_minutes;
+
+-- reservation_menu_input_values (2개)
+ALTER TABLE reservation_menu_input_values RENAME COLUMN reservation_service_id TO reservation_menu_item_id;
+ALTER TABLE reservation_menu_input_values RENAME COLUMN shop_service_input_field_id TO shop_menu_input_field_id;
+
+-- ============================================================
+-- 6) key 컬럼 제거 (id(PK)로 식별, label만 사용)
+-- ============================================================
+ALTER TABLE shop_menu_input_fields DROP COLUMN `key`;
+
+-- field_key_snapshot 제거 (label_snapshot + type_snapshot으로 충분)
+ALTER TABLE reservation_menu_input_values DROP COLUMN field_key_snapshot;
+
+-- ============================================================
+-- 7) UNIQUE 제약 재생성 (새 이름)
+-- ============================================================
+ALTER TABLE shop_menus
+  ADD UNIQUE KEY uq_shop_menus_shop_name (shop_id, name);
+
+ALTER TABLE shop_menu_tags
+  ADD UNIQUE KEY uq_shop_menu_tags (shop_menu_id, tag_id);
+
+-- key 대신 label로 중복 방지
+ALTER TABLE shop_menu_input_fields
+  ADD UNIQUE KEY uq_shop_menu_input_fields (shop_menu_id, label);
+
+ALTER TABLE reservation_menu_items
+  ADD UNIQUE KEY uq_reservation_menu_items_res_shop_menu (reservation_id, shop_menu_id);
+
+ALTER TABLE reservation_menu_input_values
+  ADD UNIQUE KEY uq_res_menu_input_values (reservation_menu_item_id, shop_menu_input_field_id);
+
+-- ============================================================
+-- 8) INDEX 재생성 (새 이름)
+-- ============================================================
+CREATE INDEX idx_shop_menus_shop_active_sort
+  ON shop_menus (shop_id, is_active, sort_order);
+
+CREATE INDEX idx_shop_menu_tags_tag
+  ON shop_menu_tags (tag_id, shop_menu_id);
+
+CREATE INDEX idx_shop_menu_input_fields_menu
+  ON shop_menu_input_fields (shop_menu_id, is_active, sort_order);
+
+CREATE INDEX idx_reservation_menu_items_reservation
+  ON reservation_menu_items (reservation_id, sort_order);
+
+CREATE INDEX idx_reservation_menu_items_shop_menu
+  ON reservation_menu_items (shop_menu_id);
+
+CREATE INDEX idx_res_menu_input_values_menu_item
+  ON reservation_menu_input_values (reservation_menu_item_id);
+
+-- ============================================================
+-- 9) FK 제약 재생성 (새 테이블/컬럼 참조)
+-- ============================================================
+ALTER TABLE reservation_menu_items
+  ADD CONSTRAINT fk_rmi_reservation FOREIGN KEY (reservation_id) REFERENCES reservations(id);
+ALTER TABLE reservation_menu_items
+  ADD CONSTRAINT fk_rmi_shop_menu FOREIGN KEY (shop_menu_id) REFERENCES shop_menus(id);
+
+ALTER TABLE reservation_menu_input_values
+  ADD CONSTRAINT fk_rmiv_menu_item FOREIGN KEY (reservation_menu_item_id) REFERENCES reservation_menu_items(id);
+ALTER TABLE reservation_menu_input_values
+  ADD CONSTRAINT fk_rmiv_input_field FOREIGN KEY (shop_menu_input_field_id) REFERENCES shop_menu_input_fields(id);
+
+ALTER TABLE shop_menu_tags
+  ADD CONSTRAINT fk_smt_shop_menu FOREIGN KEY (shop_menu_id) REFERENCES shop_menus(id);
+ALTER TABLE shop_menu_tags
+  ADD CONSTRAINT fk_smt_tag FOREIGN KEY (tag_id) REFERENCES tags(id);

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuInputValueJpaMappingTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuInputValueJpaMappingTest.java
@@ -1,0 +1,60 @@
+package com.example.easybooking.reservation.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.easybooking.reservation.domain.repository.ReservationMenuItemRepository;
+import com.example.easybooking.reservation.domain.repository.ReservationRepository;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ReservationMenuInputValueJpaMappingTest {
+
+    @Autowired
+    ReservationRepository reservationRepository;
+
+    @Autowired
+    ReservationMenuItemRepository menuItemRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    void reservationMenuInputValue_isMappedToReservationMenuInputValuesTable() {
+        Reservation reservation = reservationRepository.save(Reservation.createReservation(
+                1L, 1L, 2L,
+                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0),
+                "{}", List.of()));
+
+        ReservationMenuItem menuItem = menuItemRepository.saveAndFlush(
+                ReservationMenuItem.create(reservation.getId(), 10L, "젤네일", null, 0));
+
+        ReservationMenuInputValue inputValue = ReservationMenuInputValue.create(
+                menuItem.getId(),
+                100L,
+                "갯수",
+                "NUMBER",
+                new BigDecimal("5"),
+                null
+        );
+
+        em.persist(inputValue);
+        em.flush();
+        em.clear();
+
+        ReservationMenuInputValue found = em.find(ReservationMenuInputValue.class, inputValue.getId());
+        assertThat(found).isNotNull();
+        assertThat(found.getReservationMenuItemId()).isEqualTo(menuItem.getId());
+        assertThat(found.getShopMenuInputFieldId()).isEqualTo(100L);
+        assertThat(found.getFieldLabelSnapshot()).isEqualTo("갯수");
+        assertThat(found.getInputTypeSnapshot()).isEqualTo("NUMBER");
+        assertThat(found.getValueNumber()).isEqualByComparingTo(new BigDecimal("5"));
+        assertThat(found.getValueText()).isNull();
+    }
+}

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuInputValueUniqueConstraintTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuInputValueUniqueConstraintTest.java
@@ -1,0 +1,66 @@
+package com.example.easybooking.reservation.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.easybooking.reservation.domain.repository.ReservationMenuInputValueRepository;
+import com.example.easybooking.reservation.domain.repository.ReservationMenuItemRepository;
+import com.example.easybooking.reservation.domain.repository.ReservationRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DataJpaTest
+class ReservationMenuInputValueUniqueConstraintTest {
+
+    @Autowired
+    ReservationRepository reservationRepository;
+
+    @Autowired
+    ReservationMenuItemRepository menuItemRepository;
+
+    @Autowired
+    ReservationMenuInputValueRepository inputValueRepository;
+
+    @Test
+    void save_throwsException_whenDuplicateMenuItemIdAndFieldId() {
+        Reservation reservation = reservationRepository.save(Reservation.createReservation(
+                1L, 1L, 2L,
+                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0),
+                "{}", List.of()));
+
+        ReservationMenuItem menuItem = menuItemRepository.saveAndFlush(
+                ReservationMenuItem.create(reservation.getId(), 10L, "젤네일", null, 0));
+
+        inputValueRepository.saveAndFlush(ReservationMenuInputValue.create(
+                menuItem.getId(), 100L, "갯수", "NUMBER", new BigDecimal("5"), null));
+
+        assertThatThrownBy(() -> inputValueRepository.saveAndFlush(
+                ReservationMenuInputValue.create(
+                        menuItem.getId(), 100L, "갯수(복사)", "NUMBER", new BigDecimal("3"), null)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void save_allowsSameFieldInDifferentMenuItems() {
+        Reservation reservation = reservationRepository.save(Reservation.createReservation(
+                1L, 1L, 2L,
+                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0),
+                "{}", List.of()));
+
+        ReservationMenuItem item1 = menuItemRepository.saveAndFlush(
+                ReservationMenuItem.create(reservation.getId(), 10L, "젤네일", null, 0));
+        ReservationMenuItem item2 = menuItemRepository.saveAndFlush(
+                ReservationMenuItem.create(reservation.getId(), 20L, "아트", null, 1));
+
+        inputValueRepository.saveAndFlush(ReservationMenuInputValue.create(
+                item1.getId(), 100L, "갯수", "NUMBER", new BigDecimal("5"), null));
+        inputValueRepository.saveAndFlush(ReservationMenuInputValue.create(
+                item2.getId(), 100L, "갯수", "NUMBER", new BigDecimal("3"), null));
+        // 다른 menuItem에 동일 fieldId -> 허용
+    }
+}

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuItemJpaMappingTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuItemJpaMappingTest.java
@@ -1,0 +1,55 @@
+package com.example.easybooking.reservation.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.easybooking.reservation.domain.repository.ReservationRepository;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ReservationMenuItemJpaMappingTest {
+
+    @Autowired
+    ReservationRepository reservationRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    void reservationMenuItem_isMappedToReservationMenuItemsTable() {
+        Reservation reservation = Reservation.createReservation(
+                1L,
+                1L,
+                2L,
+                LocalDate.of(2026, 2, 11),
+                LocalTime.of(14, 0),
+                "{\"form\":{}}",
+                List.of()
+        );
+        Reservation savedReservation = reservationRepository.save(reservation);
+
+        ReservationMenuItem reservationMenuItem = ReservationMenuItem.create(
+                savedReservation.getId(),
+                10L,
+                "젤네일",
+                null,
+                0
+        );
+
+        em.persist(reservationMenuItem);
+        em.flush();
+        em.clear();
+
+        ReservationMenuItem found = em.find(ReservationMenuItem.class, reservationMenuItem.getId());
+        assertThat(found).isNotNull();
+        assertThat(found.getReservationId()).isEqualTo(savedReservation.getId());
+        assertThat(found.getShopMenuId()).isEqualTo(10L);
+        assertThat(found.getMenuNameSnapshot()).isEqualTo("젤네일");
+        assertThat(found.getSortOrder()).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuItemSnapshotIntegrationTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuItemSnapshotIntegrationTest.java
@@ -1,0 +1,50 @@
+package com.example.easybooking.reservation.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.easybooking.reservation.domain.repository.ReservationMenuItemRepository;
+import com.example.easybooking.reservation.domain.repository.ReservationRepository;
+import com.example.easybooking.shop.domain.ShopMenu;
+import com.example.easybooking.shop.repository.ShopMenuRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ReservationMenuItemSnapshotIntegrationTest {
+
+    @Autowired
+    ReservationRepository reservationRepository;
+
+    @Autowired
+    ReservationMenuItemRepository menuItemRepository;
+
+    @Autowired
+    ShopMenuRepository shopMenuRepository;
+
+    @Test
+    void snapshot_isPreserved_afterOriginalMenuNameChanges() {
+        // given: 메뉴 생성
+        ShopMenu menu = shopMenuRepository.saveAndFlush(
+                ShopMenu.create(1L, "젤네일", "기본 젤네일", true, 0));
+
+        // 예약 + 메뉴 선택 (스냅샷 = "젤네일")
+        Reservation reservation = reservationRepository.save(Reservation.createReservation(
+                1L, 1L, 2L,
+                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0),
+                "{}", List.of()));
+        ReservationMenuItem saved = menuItemRepository.saveAndFlush(
+                ReservationMenuItem.create(reservation.getId(), menu.getId(), menu.getName(), null, 0));
+
+        // when: 원본 메뉴 이름 변경
+        menu.update("젤아트", null, null);
+        shopMenuRepository.saveAndFlush(menu);
+
+        // then: 스냅샷은 원래 이름 유지
+        ReservationMenuItem found = menuItemRepository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getMenuNameSnapshot()).isEqualTo("젤네일");
+    }
+}

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuItemUniqueConstraintTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuItemUniqueConstraintTest.java
@@ -1,0 +1,56 @@
+package com.example.easybooking.reservation.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.easybooking.reservation.domain.repository.ReservationMenuItemRepository;
+import com.example.easybooking.reservation.domain.repository.ReservationRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DataJpaTest
+class ReservationMenuItemUniqueConstraintTest {
+
+    @Autowired
+    ReservationRepository reservationRepository;
+
+    @Autowired
+    ReservationMenuItemRepository reservationMenuItemRepository;
+
+    @Test
+    void save_throwsException_whenDuplicateReservationIdAndShopMenuId() {
+        Reservation saved = reservationRepository.save(Reservation.createReservation(
+                1L, 1L, 2L,
+                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0),
+                "{}", List.of()));
+
+        reservationMenuItemRepository.saveAndFlush(
+                ReservationMenuItem.create(saved.getId(), 10L, "젤네일", null, 0));
+
+        assertThatThrownBy(() -> reservationMenuItemRepository.saveAndFlush(
+                ReservationMenuItem.create(saved.getId(), 10L, "젤네일(복사)", null, 1)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void save_allowsSameMenuInDifferentReservations() {
+        Reservation r1 = reservationRepository.save(Reservation.createReservation(
+                1L, 1L, 2L,
+                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0),
+                "{}", List.of()));
+        Reservation r2 = reservationRepository.save(Reservation.createReservation(
+                1L, 1L, 3L,
+                LocalDate.of(2026, 2, 11), LocalTime.of(15, 0),
+                "{}", List.of()));
+
+        reservationMenuItemRepository.saveAndFlush(
+                ReservationMenuItem.create(r1.getId(), 10L, "젤네일", null, 0));
+        reservationMenuItemRepository.saveAndFlush(
+                ReservationMenuItem.create(r2.getId(), 10L, "젤네일", null, 0));
+        // 다른 예약에 동일 메뉴 -> 허용
+    }
+}

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationMenuInputValueServiceTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationMenuInputValueServiceTest.java
@@ -1,0 +1,246 @@
+package com.example.easybooking.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.example.easybooking.reservation.ReservationMenuInputValueWriter;
+import com.example.easybooking.reservation.domain.ReservationMenuInputValue;
+import com.example.easybooking.reservation.dto.MenuInputValueRequest;
+import com.example.easybooking.shop.ShopMenuInputFieldReader;
+import com.example.easybooking.shop.domain.InputType;
+import com.example.easybooking.shop.domain.ShopMenuInputField;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationMenuInputValueServiceTest {
+
+    @Mock
+    ShopMenuInputFieldReader inputFieldReader;
+
+    @Mock
+    ReservationMenuInputValueWriter inputValueWriter;
+
+    @InjectMocks
+    ReservationMenuInputValueService service;
+
+    private ShopMenuInputField mockField(Long id, String label, InputType type, boolean required,
+                                         BigDecimal min, BigDecimal max, BigDecimal step,
+                                         Integer maxLength) {
+        ShopMenuInputField field = mock(ShopMenuInputField.class);
+        lenient().when(field.getId()).thenReturn(id);
+        lenient().when(field.getLabel()).thenReturn(label);
+        lenient().when(field.getInputType()).thenReturn(type);
+        lenient().when(field.getRequired()).thenReturn(required);
+        lenient().when(field.getMinValue()).thenReturn(min);
+        lenient().when(field.getMaxValue()).thenReturn(max);
+        lenient().when(field.getStepValue()).thenReturn(step);
+        lenient().when(field.getMaxLength()).thenReturn(maxLength);
+        return field;
+    }
+
+    // 4-D-1: 입력값 저장 + 스냅샷
+    @Test
+    void saveInputValues_persistsWithSnapshots() {
+        ShopMenuInputField numberField = mockField(100L, "갯수", InputType.NUMBER, true,
+                new BigDecimal("1"), new BigDecimal("10"), new BigDecimal("1"), null);
+        when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(numberField));
+        when(inputValueWriter.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        List<ReservationMenuInputValue> result = service.saveInputValues(
+                1L, 10L,
+                List.of(new MenuInputValueRequest(100L, new BigDecimal("5"), null)));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getReservationMenuItemId()).isEqualTo(1L);
+        assertThat(result.get(0).getShopMenuInputFieldId()).isEqualTo(100L);
+        assertThat(result.get(0).getFieldLabelSnapshot()).isEqualTo("갯수");
+        assertThat(result.get(0).getInputTypeSnapshot()).isEqualTo("NUMBER");
+        assertThat(result.get(0).getValueNumber()).isEqualByComparingTo(new BigDecimal("5"));
+        assertThat(result.get(0).getValueText()).isNull();
+    }
+
+    // 4-D-2: required 필드 누락
+    @Test
+    void saveInputValues_throwsException_whenRequiredFieldMissing() {
+        ShopMenuInputField requiredField = mockField(100L, "갯수", InputType.NUMBER, true,
+                new BigDecimal("1"), new BigDecimal("10"), null, null);
+        when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(requiredField));
+
+        assertThatThrownBy(() -> service.saveInputValues(1L, 10L, List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("누락");
+    }
+
+    // 4-D-3: NUMBER 범위 검증
+    @Nested
+    class NumberRangeValidation {
+
+        @Test
+        void throwsException_whenValueBelowMin() {
+            ShopMenuInputField field = mockField(100L, "갯수", InputType.NUMBER, true,
+                    new BigDecimal("1"), new BigDecimal("10"), null, null);
+            when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(field));
+
+            assertThatThrownBy(() -> service.saveInputValues(1L, 10L,
+                    List.of(new MenuInputValueRequest(100L, new BigDecimal("0"), null))))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("최솟값");
+        }
+
+        @Test
+        void throwsException_whenValueAboveMax() {
+            ShopMenuInputField field = mockField(100L, "갯수", InputType.NUMBER, true,
+                    new BigDecimal("1"), new BigDecimal("10"), null, null);
+            when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(field));
+
+            assertThatThrownBy(() -> service.saveInputValues(1L, 10L,
+                    List.of(new MenuInputValueRequest(100L, new BigDecimal("15"), null))))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("최댓값");
+        }
+
+        @Test
+        void allowsBoundaryValues() {
+            ShopMenuInputField field = mockField(100L, "갯수", InputType.NUMBER, true,
+                    new BigDecimal("1"), new BigDecimal("10"), null, null);
+            when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(field));
+            when(inputValueWriter.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+            assertThat(service.saveInputValues(1L, 10L,
+                    List.of(new MenuInputValueRequest(100L, new BigDecimal("1"), null)))).hasSize(1);
+            assertThat(service.saveInputValues(1L, 10L,
+                    List.of(new MenuInputValueRequest(100L, new BigDecimal("10"), null)))).hasSize(1);
+        }
+    }
+
+    // 4-D-4: NUMBER step 검증
+    @Nested
+    class NumberStepValidation {
+
+        @Test
+        void throwsException_whenValueNotOnStep() {
+            ShopMenuInputField field = mockField(100L, "갯수", InputType.NUMBER, true,
+                    new BigDecimal("0"), new BigDecimal("100"), new BigDecimal("5"), null);
+            when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(field));
+
+            assertThatThrownBy(() -> service.saveInputValues(1L, 10L,
+                    List.of(new MenuInputValueRequest(100L, new BigDecimal("3"), null))))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("step");
+        }
+
+        @Test
+        void allowsValueOnStep() {
+            ShopMenuInputField field = mockField(100L, "갯수", InputType.NUMBER, true,
+                    new BigDecimal("0"), new BigDecimal("100"), new BigDecimal("5"), null);
+            when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(field));
+            when(inputValueWriter.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+            assertThat(service.saveInputValues(1L, 10L,
+                    List.of(new MenuInputValueRequest(100L, new BigDecimal("10"), null)))).hasSize(1);
+        }
+
+        @Test
+        void skipsStepValidation_whenStepValueNull() {
+            ShopMenuInputField field = mockField(100L, "갯수", InputType.NUMBER, true,
+                    new BigDecimal("0"), new BigDecimal("100"), null, null);
+            when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(field));
+            when(inputValueWriter.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+            assertThat(service.saveInputValues(1L, 10L,
+                    List.of(new MenuInputValueRequest(100L, new BigDecimal("3"), null)))).hasSize(1);
+        }
+    }
+
+    // 4-D-5: TEXT maxLength 검증
+    @Nested
+    class TextMaxLengthValidation {
+
+        @Test
+        void throwsException_whenTextExceedsMaxLength() {
+            ShopMenuInputField field = mockField(200L, "요청사항", InputType.TEXT, true,
+                    null, null, null, 5);
+            when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(field));
+
+            assertThatThrownBy(() -> service.saveInputValues(1L, 10L,
+                    List.of(new MenuInputValueRequest(200L, null, "여섯글자입니다"))))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("최대 길이");
+        }
+
+        @Test
+        void allowsBoundaryLength() {
+            ShopMenuInputField field = mockField(200L, "요청사항", InputType.TEXT, true,
+                    null, null, null, 5);
+            when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(field));
+            when(inputValueWriter.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+            assertThat(service.saveInputValues(1L, 10L,
+                    List.of(new MenuInputValueRequest(200L, null, "다섯글자임")))).hasSize(1);
+        }
+
+        @Test
+        void skipsLengthValidation_whenMaxLengthNull() {
+            ShopMenuInputField field = mockField(200L, "요청사항", InputType.TEXT, true,
+                    null, null, null, null);
+            when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(field));
+            when(inputValueWriter.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+            assertThat(service.saveInputValues(1L, 10L,
+                    List.of(new MenuInputValueRequest(200L, null, "아무리 길어도 괜찮습니다 매우 긴 텍스트")))).hasSize(1);
+        }
+    }
+
+    // 4-D-6: 타입 미스매치
+    @Nested
+    class TypeMismatchValidation {
+
+        @Test
+        void throwsException_whenNumberFieldHasOnlyText() {
+            ShopMenuInputField field = mockField(100L, "갯수", InputType.NUMBER, true,
+                    null, null, null, null);
+            when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(field));
+
+            assertThatThrownBy(() -> service.saveInputValues(1L, 10L,
+                    List.of(new MenuInputValueRequest(100L, null, "hello"))))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("숫자 값");
+        }
+
+        @Test
+        void throwsException_whenTextFieldHasOnlyNumber() {
+            ShopMenuInputField field = mockField(200L, "요청사항", InputType.TEXT, true,
+                    null, null, null, null);
+            when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(field));
+
+            assertThatThrownBy(() -> service.saveInputValues(1L, 10L,
+                    List.of(new MenuInputValueRequest(200L, new BigDecimal("5"), null))))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("텍스트 값");
+        }
+    }
+
+    // 4-D-7: 메뉴에 정의되지 않은 fieldId
+    @Test
+    void saveInputValues_throwsException_whenFieldNotBelongToMenu() {
+        ShopMenuInputField field = mockField(100L, "갯수", InputType.NUMBER, false,
+                null, null, null, null);
+        when(inputFieldReader.findActiveByMenuId(10L)).thenReturn(List.of(field));
+
+        assertThatThrownBy(() -> service.saveInputValues(1L, 10L,
+                List.of(new MenuInputValueRequest(999L, new BigDecimal("5"), null))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("정의되지 않은");
+    }
+}

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationMenuItemServiceTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationMenuItemServiceTest.java
@@ -1,0 +1,89 @@
+package com.example.easybooking.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.example.easybooking.reservation.ReservationMenuItemWriter;
+import com.example.easybooking.reservation.domain.ReservationMenuItem;
+import com.example.easybooking.shop.ShopMenuReader;
+import com.example.easybooking.shop.domain.ShopMenu;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationMenuItemServiceTest {
+
+    @Mock
+    ShopMenuReader shopMenuReader;
+
+    @Mock
+    ReservationMenuItemWriter reservationMenuItemWriter;
+
+    @InjectMocks
+    ReservationMenuItemService reservationMenuItemService;
+
+    @Test
+    void saveMenuItems_persistsAllMenuItemsWithSnapshots() {
+        // given
+        ShopMenu menu1 = ShopMenu.create(1L, "젤네일", "기본 젤네일", true, 0);
+        ShopMenu menu2 = ShopMenu.create(1L, "아트", "아트 추가", true, 1);
+
+        when(shopMenuReader.getById(10L)).thenReturn(menu1);
+        when(shopMenuReader.getById(20L)).thenReturn(menu2);
+        when(reservationMenuItemWriter.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        // when
+        List<ReservationMenuItem> result = reservationMenuItemService.saveMenuItems(
+                100L, 1L, List.of(10L, 20L));
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getReservationId()).isEqualTo(100L);
+        assertThat(result.get(0).getMenuNameSnapshot()).isEqualTo("젤네일");
+        assertThat(result.get(0).getShopMenuId()).isEqualTo(10L);
+        assertThat(result.get(0).getSortOrder()).isEqualTo(0);
+
+        assertThat(result.get(1).getMenuNameSnapshot()).isEqualTo("아트");
+        assertThat(result.get(1).getShopMenuId()).isEqualTo(20L);
+        assertThat(result.get(1).getSortOrder()).isEqualTo(1);
+    }
+
+    @Test
+    void saveMenuItems_throwsException_whenMenuIdsEmpty() {
+        assertThatThrownBy(() -> reservationMenuItemService.saveMenuItems(100L, 1L, List.of()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void saveMenuItems_throwsException_whenMenuIdsNull() {
+        assertThatThrownBy(() -> reservationMenuItemService.saveMenuItems(100L, 1L, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void saveMenuItems_throwsException_whenMenuBelongsToDifferentShop() {
+        ShopMenu wrongShopMenu = ShopMenu.create(2L, "다른샵메뉴", null, true, 0);
+        when(shopMenuReader.getById(10L)).thenReturn(wrongShopMenu);
+
+        assertThatThrownBy(() -> reservationMenuItemService.saveMenuItems(100L, 1L, List.of(10L)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("속하지 않습니다");
+    }
+
+    @Test
+    void saveMenuItems_throwsException_whenMenuIsInactive() {
+        ShopMenu inactiveMenu = ShopMenu.create(1L, "비활성메뉴", null, false, 0);
+        when(shopMenuReader.getById(10L)).thenReturn(inactiveMenu);
+
+        assertThatThrownBy(() -> reservationMenuItemService.saveMenuItems(100L, 1L, List.of(10L)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("비활성");
+    }
+}

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceDualWriteTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceDualWriteTest.java
@@ -1,0 +1,157 @@
+package com.example.easybooking.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.easybooking.reservation.ReservationReader;
+import com.example.easybooking.reservation.ReservationTimeBlockWriter;
+import com.example.easybooking.reservation.ReservationWriter;
+import com.example.easybooking.reservation.TimeBlockGenerator;
+import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.reservation.domain.ReservationMenuItem;
+import com.example.easybooking.reservation.dto.MenuInputValueRequest;
+import com.example.easybooking.reservation.dto.MenuSelectionRequest;
+import com.example.easybooking.reservation.dto.ReservationCreateRequest;
+import com.example.easybooking.reservation.dto.ReservationResponse;
+import com.example.easybooking.shop.ShopReader;
+import com.example.easybooking.shop.domain.Shop;
+import com.example.easybooking.staff.StaffReader;
+import com.example.easybooking.staff.domain.Staff;
+import com.example.easybooking.user.UserReader;
+import com.example.easybooking.user.domain.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceDualWriteTest {
+
+    @Mock ReservationWriter reservationWriter;
+    @Mock ReservationReader reservationReader;
+    @Mock UserReader userReader;
+    @Mock ShopReader shopReader;
+    @Mock StaffReader staffReader;
+    @Mock ApplicationEventPublisher eventPublisher;
+    @Mock TimeBlockGenerator timeBlockGenerator;
+    @Mock ReservationTimeBlockWriter reservationTimeBlockWriter;
+    @Mock ReservationMenuItemService reservationMenuItemService;
+    @Mock ReservationMenuInputValueService reservationMenuInputValueService;
+
+    ReservationService reservationService;
+
+    @BeforeEach
+    void setUp() {
+        reservationService = new ReservationService(
+                reservationWriter, reservationReader, userReader, shopReader, staffReader,
+                new ObjectMapper(), eventPublisher, timeBlockGenerator,
+                reservationTimeBlockWriter,
+                reservationMenuItemService, reservationMenuInputValueService
+        );
+    }
+
+    private ReservationCreateRequest buildRequest(List<MenuSelectionRequest> menuSelections) {
+        ReservationCreateRequest request = new ReservationCreateRequest();
+        request.setShopId(1L);
+        request.setStaffId(10L);
+
+        Map<String, String> formData = new HashMap<>();
+        formData.put("date", "2026-02-11");
+        formData.put("time", "14:00");
+        request.setFormData(formData);
+        request.setMenuSelections(menuSelections);
+        return request;
+    }
+
+    private void setupCommonMocks() {
+        Shop shop = mock(Shop.class);
+        when(shop.getOwnerId()).thenReturn(100L);
+        when(shopReader.read(1L)).thenReturn(shop);
+
+        Staff staff = mock(Staff.class);
+        when(staff.getShopId()).thenReturn(1L);
+        when(staffReader.read(10L)).thenReturn(staff);
+
+        User customer = mock(User.class);
+        when(customer.getName()).thenReturn("고객");
+        when(userReader.read(200L)).thenReturn(customer);
+
+        when(reservationWriter.save(any(Reservation.class))).thenAnswer(inv -> {
+            Reservation r = inv.getArgument(0);
+            try {
+                var idField = Reservation.class.getDeclaredField("id");
+                idField.setAccessible(true);
+                idField.set(r, 999L);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+            return r;
+        });
+    }
+
+    // 4-E-1: formDataJson + 새 테이블 동시 저장
+    @Test
+    void createReservation_savesFormDataJsonAndMenuItems() {
+        setupCommonMocks();
+
+        ReservationMenuItem item1 = ReservationMenuItem.create(999L, 50L, "젤네일", null, 0);
+        ReservationMenuItem item2 = ReservationMenuItem.create(999L, 60L, "아트", null, 1);
+        when(reservationMenuItemService.saveMenuItems(eq(999L), eq(1L), eq(List.of(50L, 60L))))
+                .thenReturn(List.of(item1, item2));
+
+        ReservationCreateRequest request = buildRequest(List.of(
+                new MenuSelectionRequest(50L, List.of()),
+                new MenuSelectionRequest(60L, List.of(
+                        new MenuInputValueRequest(100L, new BigDecimal("5"), null)))
+        ));
+
+        ReservationResponse response = reservationService.createReservation(request, 200L);
+
+        assertThat(response).isNotNull();
+        verify(reservationMenuItemService).saveMenuItems(999L, 1L, List.of(50L, 60L));
+        verify(reservationMenuInputValueService).saveInputValues(
+                eq(item2.getId()), eq(60L), anyList());
+    }
+
+    // 4-E-1 보완: menuSelections가 null이면 레거시 모드
+    @Test
+    void createReservation_skipsMenuSave_whenMenuSelectionsNull() {
+        setupCommonMocks();
+
+        ReservationCreateRequest request = buildRequest(null);
+        reservationService.createReservation(request, 200L);
+
+        verify(reservationMenuItemService, never()).saveMenuItems(anyLong(), anyLong(), anyList());
+    }
+
+    // 4-E-2: 메뉴 저장 실패 시 예외 전파 (트랜잭션 롤백)
+    @Test
+    void createReservation_propagatesException_whenMenuSaveFails() {
+        setupCommonMocks();
+
+        when(reservationMenuItemService.saveMenuItems(anyLong(), anyLong(), anyList()))
+                .thenThrow(new IllegalArgumentException("메뉴 저장 실패"));
+
+        ReservationCreateRequest request = buildRequest(List.of(
+                new MenuSelectionRequest(50L, List.of())));
+
+        assertThatThrownBy(() -> reservationService.createReservation(request, 200L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("메뉴 저장 실패");
+    }
+}

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceDualWriteTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceDualWriteTest.java
@@ -52,6 +52,8 @@ class ReservationServiceDualWriteTest {
     @Mock ReservationTimeBlockWriter reservationTimeBlockWriter;
     @Mock ReservationMenuItemService reservationMenuItemService;
     @Mock ReservationMenuInputValueService reservationMenuInputValueService;
+    @Mock com.example.easybooking.reservation.ReservationMenuItemReader menuItemReader;
+    @Mock com.example.easybooking.reservation.ReservationMenuInputValueReader inputValueReader;
 
     ReservationService reservationService;
 
@@ -61,7 +63,8 @@ class ReservationServiceDualWriteTest {
                 reservationWriter, reservationReader, userReader, shopReader, staffReader,
                 new ObjectMapper(), eventPublisher, timeBlockGenerator,
                 reservationTimeBlockWriter,
-                reservationMenuItemService, reservationMenuInputValueService
+                reservationMenuItemService, reservationMenuInputValueService,
+                menuItemReader, inputValueReader
         );
     }
 

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetDetailMenuResponseTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetDetailMenuResponseTest.java
@@ -1,0 +1,228 @@
+package com.example.easybooking.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.example.easybooking.reservation.ReservationMenuInputValueReader;
+import com.example.easybooking.reservation.ReservationMenuItemReader;
+import com.example.easybooking.reservation.ReservationReader;
+import com.example.easybooking.reservation.ReservationTimeBlockWriter;
+import com.example.easybooking.reservation.ReservationWriter;
+import com.example.easybooking.reservation.TimeBlockGenerator;
+import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.reservation.domain.ReservationMenuInputValue;
+import com.example.easybooking.reservation.domain.ReservationMenuItem;
+import com.example.easybooking.reservation.dto.ReservationDetailResponse;
+import com.example.easybooking.reservation.dto.ReservationMenuItemResponse;
+import com.example.easybooking.shop.ShopReader;
+import com.example.easybooking.shop.domain.Shop;
+import com.example.easybooking.staff.StaffReader;
+import com.example.easybooking.user.UserReader;
+import com.example.easybooking.user.domain.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceGetDetailMenuResponseTest {
+
+    @Mock ReservationWriter reservationWriter;
+    @Mock ReservationReader reservationReader;
+    @Mock UserReader userReader;
+    @Mock ShopReader shopReader;
+    @Mock StaffReader staffReader;
+    @Mock ApplicationEventPublisher eventPublisher;
+    @Mock TimeBlockGenerator timeBlockGenerator;
+    @Mock ReservationTimeBlockWriter reservationTimeBlockWriter;
+    @Mock ReservationMenuItemService reservationMenuItemService;
+    @Mock ReservationMenuInputValueService reservationMenuInputValueService;
+    @Mock ReservationMenuItemReader menuItemReader;
+    @Mock ReservationMenuInputValueReader inputValueReader;
+
+    ReservationService reservationService;
+
+    @BeforeEach
+    void setUp() {
+        reservationService = new ReservationService(
+                reservationWriter, reservationReader, userReader, shopReader, staffReader,
+                new ObjectMapper(), eventPublisher, timeBlockGenerator,
+                reservationTimeBlockWriter,
+                reservationMenuItemService, reservationMenuInputValueService,
+                menuItemReader, inputValueReader
+        );
+    }
+
+    // --- 공통 헬퍼 ---
+
+    private Reservation mockReservation(Long reservationId, Long customerId, Long ownerUserId, Long shopId) {
+        Reservation r = mock(Reservation.class);
+        when(r.getId()).thenReturn(reservationId);
+        when(r.getCustomerId()).thenReturn(customerId);
+        when(r.getOwnerUserId()).thenReturn(ownerUserId);
+        when(r.getShopId()).thenReturn(shopId);
+        when(r.getFormDataJson()).thenReturn(
+                "{\"part\":\"손\",\"removal\":\"예\",\"requests\":\"요청\",\"extend\":\"0\",\"wrapping\":\"0\"}");
+        when(r.getDesignImageURLs()).thenReturn(List.of());
+        when(r.getDate()).thenReturn(LocalDate.of(2026, 2, 11));
+        when(r.getTime()).thenReturn(LocalTime.of(14, 0));
+        when(r.getStatus()).thenReturn(Reservation.Status.PENDING);
+        return r;
+    }
+
+    private void setupUserAndShop(Long customerId, Long shopId) {
+        User customer = mock(User.class);
+        when(customer.getName()).thenReturn("고객");
+        when(customer.getPhoneNumber()).thenReturn("01012345678");
+        when(userReader.read(customerId)).thenReturn(customer);
+
+        Shop shop = mock(Shop.class);
+        when(shop.getBusinessName()).thenReturn("테스트샵");
+        when(shopReader.read(shopId)).thenReturn(shop);
+    }
+
+    private ReservationMenuItem mockMenuItem(Long itemId,
+                                             Long shopMenuId, String name, Long price, int sortOrder) {
+        ReservationMenuItem item = mock(ReservationMenuItem.class);
+        when(item.getId()).thenReturn(itemId);
+        when(item.getShopMenuId()).thenReturn(shopMenuId);
+        when(item.getMenuNameSnapshot()).thenReturn(name);
+        when(item.getPriceSnapshot()).thenReturn(price);
+        when(item.getSortOrder()).thenReturn(sortOrder);
+        return item;
+    }
+
+    private ReservationMenuInputValue mockInputValue(Long menuItemId,
+                                                     String label, String type,
+                                                     BigDecimal number, String text) {
+        ReservationMenuInputValue iv = mock(ReservationMenuInputValue.class);
+        when(iv.getReservationMenuItemId()).thenReturn(menuItemId);
+        when(iv.getFieldLabelSnapshot()).thenReturn(label);
+        when(iv.getInputTypeSnapshot()).thenReturn(type);
+        when(iv.getValueNumber()).thenReturn(number);
+        when(iv.getValueText()).thenReturn(text);
+        return iv;
+    }
+
+    // --- 5-A-1 ---
+
+    @Test
+    @DisplayName("5-A-1: 예약 상세 조회 시 선택된 메뉴 목록 + 입력값이 포함된다")
+    void getReservationDetail_containsMenusWithInputValues() {
+        // given
+        Long reservationId = 1L;
+        Long customerId = 10L;
+        Long shopId = 100L;
+
+        Reservation reservation = mockReservation(reservationId, customerId, customerId, shopId);
+        when(reservationReader.getById(reservationId)).thenReturn(reservation);
+        setupUserAndShop(customerId, shopId);
+
+        ReservationMenuItem item1 = mockMenuItem(101L, 50L, "젤네일", 50000L, 0);
+        ReservationMenuItem item2 = mockMenuItem(102L, 60L, "아트", 30000L, 1);
+        when(menuItemReader.findByReservationId(reservationId)).thenReturn(List.of(item1, item2));
+
+        ReservationMenuInputValue iv1 = mockInputValue(101L, "길이", "NUMBER",
+                new BigDecimal("5"), null);
+        when(inputValueReader.findByReservationMenuItemIds(List.of(101L, 102L)))
+                .thenReturn(List.of(iv1));
+
+        // when
+        ReservationDetailResponse result = reservationService.getReservationDetail(reservationId, customerId);
+
+        // then
+        assertThat(result.getMenus()).hasSize(2);
+
+        ReservationMenuItemResponse menu1 = result.getMenus().get(0);
+        assertThat(menu1.getMenuNameSnapshot()).isEqualTo("젤네일");
+        assertThat(menu1.getShopMenuId()).isEqualTo(50L);
+        assertThat(menu1.getPriceSnapshot()).isEqualTo(50000L);
+        assertThat(menu1.getInputValues()).hasSize(1);
+        assertThat(menu1.getInputValues().get(0).getFieldLabelSnapshot()).isEqualTo("길이");
+        assertThat(menu1.getInputValues().get(0).getValueNumber()).isEqualByComparingTo(new BigDecimal("5"));
+
+        ReservationMenuItemResponse menu2 = result.getMenus().get(1);
+        assertThat(menu2.getMenuNameSnapshot()).isEqualTo("아트");
+        assertThat(menu2.getInputValues()).isEmpty();
+    }
+
+    // --- 5-A-2 ---
+
+    @Test
+    @DisplayName("5-A-2: reservation_menu_items 데이터가 없으면 formDataJson fallback")
+    void getReservationDetail_fallsBackToFormDataJson_whenNoMenuItems() {
+        // given
+        Long reservationId = 2L;
+        Long customerId = 20L;
+        Long shopId = 200L;
+
+        Reservation reservation = mockReservation(reservationId, customerId, customerId, shopId);
+        when(reservationReader.getById(reservationId)).thenReturn(reservation);
+        setupUserAndShop(customerId, shopId);
+
+        when(menuItemReader.findByReservationId(reservationId)).thenReturn(List.of());
+
+        // when
+        ReservationDetailResponse result = reservationService.getReservationDetail(reservationId, customerId);
+
+        // then: formDataJson 기반 필드가 정상 반환
+        assertThat(result.getPart()).isEqualTo("손");
+        assertThat(result.getRemoval()).isEqualTo("예");
+        assertThat(result.getRequests()).isEqualTo("요청");
+
+        // then: menus는 빈 리스트
+        assertThat(result.getMenus()).isEmpty();
+    }
+
+    // --- 5-A-3 ---
+
+    @Test
+    @DisplayName("5-A-3: 메뉴별 입력값이 해당 메뉴 하위로 중첩 반환된다")
+    void getReservationDetail_nestsInputValuesUnderCorrectMenu() {
+        // given
+        Long reservationId = 3L;
+        Long customerId = 30L;
+        Long shopId = 300L;
+
+        Reservation reservation = mockReservation(reservationId, customerId, customerId, shopId);
+        when(reservationReader.getById(reservationId)).thenReturn(reservation);
+        setupUserAndShop(customerId, shopId);
+
+        ReservationMenuItem menuA = mockMenuItem(201L, 70L, "메뉴A", 40000L, 0);
+        ReservationMenuItem menuB = mockMenuItem(202L, 80L, "메뉴B", 20000L, 1);
+        when(menuItemReader.findByReservationId(reservationId)).thenReturn(List.of(menuA, menuB));
+
+        ReservationMenuInputValue ivA1 = mockInputValue(201L, "길이", "NUMBER",
+                new BigDecimal("3"), null);
+        ReservationMenuInputValue ivA2 = mockInputValue(201L, "요청사항", "TEXT",
+                null, "짧게");
+        when(inputValueReader.findByReservationMenuItemIds(List.of(201L, 202L)))
+                .thenReturn(List.of(ivA1, ivA2));
+
+        // when
+        ReservationDetailResponse result = reservationService.getReservationDetail(reservationId, customerId);
+
+        // then: 메뉴 A -> inputValues 2개
+        ReservationMenuItemResponse resultMenuA = result.getMenus().get(0);
+        assertThat(resultMenuA.getMenuNameSnapshot()).isEqualTo("메뉴A");
+        assertThat(resultMenuA.getInputValues()).hasSize(2);
+        assertThat(resultMenuA.getInputValues().get(0).getFieldLabelSnapshot()).isEqualTo("길이");
+        assertThat(resultMenuA.getInputValues().get(1).getFieldLabelSnapshot()).isEqualTo("요청사항");
+        assertThat(resultMenuA.getInputValues().get(1).getValueText()).isEqualTo("짧게");
+
+        // then: 메뉴 B -> inputValues 0개
+        ReservationMenuItemResponse resultMenuB = result.getMenus().get(1);
+        assertThat(resultMenuB.getMenuNameSnapshot()).isEqualTo("메뉴B");
+        assertThat(resultMenuB.getInputValues()).isEmpty();
+    }
+}

--- a/src/test/java/com/example/easybooking/shop/ShopMenuReaderTest.java
+++ b/src/test/java/com/example/easybooking/shop/ShopMenuReaderTest.java
@@ -1,0 +1,65 @@
+package com.example.easybooking.shop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.easybooking.shop.domain.ShopMenu;
+import com.example.easybooking.shop.repository.ShopMenuRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ShopMenuReaderTest {
+
+    @Autowired
+    ShopMenuRepository shopMenuRepository;
+
+    ShopMenuReader reader;
+
+    @BeforeEach
+    void setUp() {
+        shopMenuRepository.deleteAll();
+        reader = new ShopMenuReader(shopMenuRepository);
+    }
+
+    @Test
+    void findActiveByShopId_returnsActiveMenusSortedBySortOrder() {
+        shopMenuRepository.save(ShopMenu.create(1L, "메뉴C", null, true, 2));
+        shopMenuRepository.save(ShopMenu.create(1L, "메뉴A", null, true, 0));
+        shopMenuRepository.save(ShopMenu.create(1L, "메뉴B", null, true, 1));
+        shopMenuRepository.save(ShopMenu.create(1L, "비활성메뉴", null, false, 3));
+
+        List<ShopMenu> result = reader.findActiveByShopId(1L);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getName()).isEqualTo("메뉴A");
+        assertThat(result.get(1).getName()).isEqualTo("메뉴B");
+        assertThat(result.get(2).getName()).isEqualTo("메뉴C");
+    }
+
+    @Test
+    void findActiveByShopId_returnsEmptyList_whenNoMenus() {
+        List<ShopMenu> result = reader.findActiveByShopId(999L);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void getById_returnsMenu_whenExists() {
+        ShopMenu saved = shopMenuRepository.save(ShopMenu.create(1L, "젤네일", null, true, 0));
+
+        ShopMenu found = reader.getById(saved.getId());
+
+        assertThat(found.getId()).isEqualTo(saved.getId());
+        assertThat(found.getName()).isEqualTo("젤네일");
+    }
+
+    @Test
+    void getById_throwsException_whenNotFound() {
+        assertThatThrownBy(() -> reader.getById(999L))
+                .isInstanceOf(RuntimeException.class);
+    }
+}

--- a/src/test/java/com/example/easybooking/shop/ShopMenuTagFilterTest.java
+++ b/src/test/java/com/example/easybooking/shop/ShopMenuTagFilterTest.java
@@ -1,0 +1,82 @@
+package com.example.easybooking.shop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.easybooking.shop.domain.ShopMenu;
+import com.example.easybooking.shop.domain.ShopMenuTag;
+import com.example.easybooking.shop.domain.Tag;
+import com.example.easybooking.shop.repository.ShopMenuRepository;
+import com.example.easybooking.shop.repository.ShopMenuTagRepository;
+import com.example.easybooking.shop.repository.TagRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ShopMenuTagFilterTest {
+
+    @Autowired ShopMenuRepository shopMenuRepository;
+    @Autowired TagRepository tagRepository;
+    @Autowired ShopMenuTagRepository shopMenuTagRepository;
+
+    ShopMenuReader reader;
+
+    @BeforeEach
+    void setUp() {
+        shopMenuTagRepository.deleteAll();
+        shopMenuRepository.deleteAll();
+        tagRepository.deleteAll();
+        reader = new ShopMenuReader(shopMenuRepository);
+    }
+
+    @Test
+    void findActiveByShopIdAndTagIds_returnsMenusWithTag() {
+        ShopMenu m1 = shopMenuRepository.save(ShopMenu.create(1L, "젤네일", null, true, 0));
+        ShopMenu m2 = shopMenuRepository.save(ShopMenu.create(1L, "페디큐어", null, true, 1));
+        shopMenuRepository.save(ShopMenu.create(1L, "왁싱", null, true, 2));
+
+        Tag t1 = tagRepository.save(Tag.create("손관리"));
+        shopMenuTagRepository.save(ShopMenuTag.create(m1.getId(), t1.getId()));
+        shopMenuTagRepository.save(ShopMenuTag.create(m2.getId(), t1.getId()));
+
+        List<ShopMenu> result = reader.findActiveByShopIdAndTagIds(1L, List.of(t1.getId()));
+
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(ShopMenu::getName).containsExactly("젤네일", "페디큐어");
+    }
+
+    @Test
+    void findActiveByShopIdAndTagIds_orFilter_multipleTagIds() {
+        ShopMenu m1 = shopMenuRepository.save(ShopMenu.create(1L, "젤네일", null, true, 0));
+        ShopMenu m2 = shopMenuRepository.save(ShopMenu.create(1L, "페디큐어", null, true, 1));
+
+        Tag t1 = tagRepository.save(Tag.create("손관리"));
+        Tag t2 = tagRepository.save(Tag.create("발관리"));
+        shopMenuTagRepository.save(ShopMenuTag.create(m1.getId(), t1.getId()));
+        shopMenuTagRepository.save(ShopMenuTag.create(m2.getId(), t2.getId()));
+
+        List<ShopMenu> result = reader.findActiveByShopIdAndTagIds(1L, List.of(t1.getId(), t2.getId()));
+
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void findActiveByShopIdAndTagIds_excludesInactiveMenus() {
+        ShopMenu m1 = shopMenuRepository.save(ShopMenu.create(1L, "젤네일", null, false, 0));
+        Tag t1 = tagRepository.save(Tag.create("손관리"));
+        shopMenuTagRepository.save(ShopMenuTag.create(m1.getId(), t1.getId()));
+
+        List<ShopMenu> result = reader.findActiveByShopIdAndTagIds(1L, List.of(t1.getId()));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void findActiveByShopIdAndTagIds_returnsEmpty_whenTagNotFound() {
+        List<ShopMenu> result = reader.findActiveByShopIdAndTagIds(1L, List.of(999L));
+
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/com/example/easybooking/shop/ShopMenuWriterTest.java
+++ b/src/test/java/com/example/easybooking/shop/ShopMenuWriterTest.java
@@ -1,0 +1,27 @@
+package com.example.easybooking.shop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.easybooking.shop.domain.ShopMenu;
+import com.example.easybooking.shop.repository.ShopMenuRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ShopMenuWriterTest {
+
+    @Autowired
+    ShopMenuRepository shopMenuRepository;
+
+    @Test
+    void save_persistsShopMenuAndAssignsId() {
+        ShopMenuWriter writer = new ShopMenuWriter(shopMenuRepository);
+
+        ShopMenu saved = writer.save(ShopMenu.create(1L, "젤네일", "기본 젤네일", true, 0));
+
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getShopId()).isEqualTo(1L);
+        assertThat(saved.getName()).isEqualTo("젤네일");
+    }
+}

--- a/src/test/java/com/example/easybooking/shop/domain/ShopMenuInputFieldTest.java
+++ b/src/test/java/com/example/easybooking/shop/domain/ShopMenuInputFieldTest.java
@@ -1,0 +1,154 @@
+package com.example.easybooking.shop.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.easybooking.shop.repository.ShopMenuInputFieldRepository;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DataJpaTest
+class ShopMenuInputFieldTest {
+
+    @Autowired EntityManager em;
+    @Autowired ShopMenuInputFieldRepository repository;
+
+    // --- 3-A-1: 매핑 ---
+    @Test
+    void canPersistAndLoadInputField() {
+        ShopMenuInputField field = ShopMenuInputField.create(
+                1L, "갯수", InputType.NUMBER, true,
+                BigDecimal.ONE, BigDecimal.TEN, BigDecimal.ONE,
+                null, null, 0);
+
+        em.persist(field);
+        em.flush();
+        em.clear();
+
+        ShopMenuInputField found = em.find(ShopMenuInputField.class, field.getId());
+        assertThat(found.getId()).isNotNull();
+        assertThat(found.getShopMenuId()).isEqualTo(1L);
+        assertThat(found.getLabel()).isEqualTo("갯수");
+        assertThat(found.getInputType()).isEqualTo(InputType.NUMBER);
+        assertThat(found.getRequired()).isTrue();
+        assertThat(found.getMinValue()).isEqualByComparingTo(BigDecimal.ONE);
+        assertThat(found.getMaxValue()).isEqualByComparingTo(BigDecimal.TEN);
+    }
+
+    // --- 3-A-2: UNIQUE ---
+    @Test
+    void save_throwsException_whenDuplicateMenuIdAndLabel() {
+        repository.saveAndFlush(ShopMenuInputField.create(
+                1L, "갯수", InputType.NUMBER, true,
+                null, null, null, null, null, 0));
+
+        assertThatThrownBy(() -> repository.saveAndFlush(ShopMenuInputField.create(
+                1L, "갯수", InputType.TEXT, false,
+                null, null, null, null, null, 1)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void save_allowsSameLabelInDifferentMenu() {
+        repository.saveAndFlush(ShopMenuInputField.create(
+                1L, "갯수", InputType.NUMBER, true, null, null, null, null, null, 0));
+        repository.saveAndFlush(ShopMenuInputField.create(
+                2L, "갯수", InputType.NUMBER, true, null, null, null, null, null, 0));
+        // no exception
+    }
+
+    // --- 3-A-3: inputType 제한 ---
+    @Test
+    void create_acceptsNumberType() {
+        ShopMenuInputField field = ShopMenuInputField.create(
+                1L, "갯수", InputType.NUMBER, true, null, null, null, null, null, 0);
+        assertThat(field.getInputType()).isEqualTo(InputType.NUMBER);
+    }
+
+    @Test
+    void create_acceptsTextType() {
+        ShopMenuInputField field = ShopMenuInputField.create(
+                1L, "요청사항", InputType.TEXT, false, null, null, null, 100, null, 0);
+        assertThat(field.getInputType()).isEqualTo(InputType.TEXT);
+    }
+
+    // --- 3-B-1: NUMBER minValue > maxValue ---
+    @Test
+    void create_throwsException_whenMinValueGreaterThanMaxValue() {
+        assertThatThrownBy(() -> ShopMenuInputField.create(
+                1L, "갯수", InputType.NUMBER, true,
+                BigDecimal.TEN, BigDecimal.valueOf(5), null, null, null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("minValue");
+    }
+
+    @Test
+    void create_allowsMinValueEqualsMaxValue() {
+        ShopMenuInputField field = ShopMenuInputField.create(
+                1L, "갯수", InputType.NUMBER, true,
+                BigDecimal.valueOf(5), BigDecimal.valueOf(5), null, null, null, 0);
+        assertThat(field.getMinValue()).isEqualByComparingTo(field.getMaxValue());
+    }
+
+    // --- 3-B-2: NUMBER stepValue <= 0 ---
+    @Test
+    void create_throwsException_whenStepValueZero() {
+        assertThatThrownBy(() -> ShopMenuInputField.create(
+                1L, "갯수", InputType.NUMBER, true,
+                null, null, BigDecimal.ZERO, null, null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("stepValue");
+    }
+
+    @Test
+    void create_allowsNullStepValue() {
+        ShopMenuInputField field = ShopMenuInputField.create(
+                1L, "갯수", InputType.NUMBER, true,
+                null, null, null, null, null, 0);
+        assertThat(field.getStepValue()).isNull();
+    }
+
+    // --- 3-B-3: TEXT maxLength <= 0 ---
+    @Test
+    void create_throwsException_whenMaxLengthZero() {
+        assertThatThrownBy(() -> ShopMenuInputField.create(
+                1L, "요청사항", InputType.TEXT, false,
+                null, null, null, 0, null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxLength");
+    }
+
+    @Test
+    void create_allowsNullMaxLength() {
+        ShopMenuInputField field = ShopMenuInputField.create(
+                1L, "요청사항", InputType.TEXT, false,
+                null, null, null, null, null, 0);
+        assertThat(field.getMaxLength()).isNull();
+    }
+
+    // --- 3-B-4: TEXT에 min/max/step 무시 ---
+    @Test
+    void create_ignoresNumberFieldsForTextType() {
+        ShopMenuInputField field = ShopMenuInputField.create(
+                1L, "요청사항", InputType.TEXT, false,
+                BigDecimal.ONE, BigDecimal.TEN, BigDecimal.ONE, 100, null, 0);
+        assertThat(field.getMinValue()).isNull();
+        assertThat(field.getMaxValue()).isNull();
+        assertThat(field.getStepValue()).isNull();
+        assertThat(field.getMaxLength()).isEqualTo(100);
+    }
+
+    // --- 3-B-5: NUMBER에 maxLength 무시 ---
+    @Test
+    void create_ignoresMaxLengthForNumberType() {
+        ShopMenuInputField field = ShopMenuInputField.create(
+                1L, "갯수", InputType.NUMBER, true,
+                BigDecimal.ONE, BigDecimal.TEN, null, 100, null, 0);
+        assertThat(field.getMaxLength()).isNull();
+        assertThat(field.getMinValue()).isEqualByComparingTo(BigDecimal.ONE);
+    }
+}

--- a/src/test/java/com/example/easybooking/shop/domain/ShopMenuJpaMappingTest.java
+++ b/src/test/java/com/example/easybooking/shop/domain/ShopMenuJpaMappingTest.java
@@ -1,0 +1,33 @@
+package com.example.easybooking.shop.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ShopMenuJpaMappingTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Test
+    void canPersistAndLoadShopMenu() {
+        ShopMenu menu = ShopMenu.create(1L, "젤네일", "기본 젤네일", true, 0);
+
+        em.persist(menu);
+        em.flush();
+        em.clear();
+
+        assertThat(menu.getId()).isNotNull();
+
+        ShopMenu found = em.find(ShopMenu.class, menu.getId());
+        assertThat(found.getShopId()).isEqualTo(1L);
+        assertThat(found.getName()).isEqualTo("젤네일");
+        assertThat(found.getDescription()).isEqualTo("기본 젤네일");
+        assertThat(found.getIsActive()).isTrue();
+        assertThat(found.getSortOrder()).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/example/easybooking/shop/domain/ShopMenuTagJpaMappingTest.java
+++ b/src/test/java/com/example/easybooking/shop/domain/ShopMenuTagJpaMappingTest.java
@@ -1,0 +1,58 @@
+package com.example.easybooking.shop.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.easybooking.shop.repository.ShopMenuTagRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DataJpaTest
+class ShopMenuTagJpaMappingTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    ShopMenuTagRepository shopMenuTagRepository;
+
+    @Test
+    void canPersistAndLoadShopMenuTag() {
+        ShopMenuTag smt = ShopMenuTag.create(1L, 1L);
+
+        em.persist(smt);
+        em.flush();
+        em.clear();
+
+        assertThat(smt.getId()).isNotNull();
+
+        ShopMenuTag found = em.find(ShopMenuTag.class, smt.getId());
+        assertThat(found.getShopMenuId()).isEqualTo(1L);
+        assertThat(found.getTagId()).isEqualTo(1L);
+    }
+
+    @Test
+    void save_throwsException_whenDuplicateMenuAndTag() {
+        shopMenuTagRepository.saveAndFlush(ShopMenuTag.create(1L, 1L));
+
+        assertThatThrownBy(() -> shopMenuTagRepository.saveAndFlush(ShopMenuTag.create(1L, 1L)))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void save_allowsSameMenuDifferentTag() {
+        shopMenuTagRepository.saveAndFlush(ShopMenuTag.create(1L, 1L));
+        shopMenuTagRepository.saveAndFlush(ShopMenuTag.create(1L, 2L));
+        // no exception
+    }
+
+    @Test
+    void save_allowsSameTagDifferentMenu() {
+        shopMenuTagRepository.saveAndFlush(ShopMenuTag.create(1L, 1L));
+        shopMenuTagRepository.saveAndFlush(ShopMenuTag.create(2L, 1L));
+        // no exception
+    }
+}

--- a/src/test/java/com/example/easybooking/shop/domain/ShopMenuUniqueConstraintTest.java
+++ b/src/test/java/com/example/easybooking/shop/domain/ShopMenuUniqueConstraintTest.java
@@ -1,0 +1,38 @@
+package com.example.easybooking.shop.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.easybooking.shop.repository.ShopMenuRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DataJpaTest
+class ShopMenuUniqueConstraintTest {
+
+    @Autowired
+    ShopMenuRepository shopMenuRepository;
+
+    @Test
+    void save_throwsException_whenDuplicateShopIdAndName() {
+        shopMenuRepository.saveAndFlush(
+                ShopMenu.create(1L, "젤네일", "기본 젤네일", true, 0)
+        );
+
+        assertThatThrownBy(() -> shopMenuRepository.saveAndFlush(
+                ShopMenu.create(1L, "젤네일", "다른 설명", true, 1)
+        )).isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void save_allowsSameNameInDifferentShop() {
+        shopMenuRepository.saveAndFlush(
+                ShopMenu.create(1L, "젤네일", null, true, 0)
+        );
+        shopMenuRepository.saveAndFlush(
+                ShopMenu.create(2L, "젤네일", null, true, 0)
+        );
+        // 예외 없이 성공
+    }
+}

--- a/src/test/java/com/example/easybooking/shop/domain/TagJpaMappingTest.java
+++ b/src/test/java/com/example/easybooking/shop/domain/TagJpaMappingTest.java
@@ -1,0 +1,43 @@
+package com.example.easybooking.shop.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.example.easybooking.shop.repository.TagRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@DataJpaTest
+class TagJpaMappingTest {
+
+    @Autowired
+    EntityManager em;
+
+    @Autowired
+    TagRepository tagRepository;
+
+    @Test
+    void canPersistAndLoadTag() {
+        Tag tag = Tag.create("손관리");
+
+        em.persist(tag);
+        em.flush();
+        em.clear();
+
+        assertThat(tag.getId()).isNotNull();
+
+        Tag found = em.find(Tag.class, tag.getId());
+        assertThat(found.getName()).isEqualTo("손관리");
+    }
+
+    @Test
+    void save_throwsException_whenDuplicateName() {
+        tagRepository.saveAndFlush(Tag.create("손관리"));
+
+        assertThatThrownBy(() -> tagRepository.saveAndFlush(Tag.create("손관리")))
+                .isInstanceOf(DataIntegrityViolationException.class);
+    }
+}

--- a/src/test/java/com/example/easybooking/shop/service/ShopMenuInputFieldServiceTest.java
+++ b/src/test/java/com/example/easybooking/shop/service/ShopMenuInputFieldServiceTest.java
@@ -1,0 +1,92 @@
+package com.example.easybooking.shop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.easybooking.shop.ShopMenuInputFieldReader;
+import com.example.easybooking.shop.ShopMenuInputFieldWriter;
+import com.example.easybooking.shop.domain.InputType;
+import com.example.easybooking.shop.domain.ShopMenuInputField;
+import com.example.easybooking.shop.dto.request.CreateInputFieldRequest;
+import com.example.easybooking.shop.dto.request.UpdateInputFieldRequest;
+import com.example.easybooking.shop.dto.response.InputFieldResponse;
+import com.example.easybooking.shop.repository.ShopMenuInputFieldRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ShopMenuInputFieldServiceTest {
+
+    @Autowired ShopMenuInputFieldRepository repository;
+
+    ShopMenuInputFieldService service;
+
+    @BeforeEach
+    void setUp() {
+        repository.deleteAll();
+        ShopMenuInputFieldReader reader = new ShopMenuInputFieldReader(repository);
+        ShopMenuInputFieldWriter writer = new ShopMenuInputFieldWriter(repository);
+        service = new ShopMenuInputFieldService(reader, writer);
+    }
+
+    @Test
+    void create_returnsCreatedField() {
+        CreateInputFieldRequest request = new CreateInputFieldRequest(
+                "손연장 갯수", "NUMBER", true,
+                BigDecimal.ONE, BigDecimal.TEN, BigDecimal.ONE,
+                null, null, 0);
+
+        InputFieldResponse response = service.create(1L, request);
+
+        assertThat(response.getId()).isNotNull();
+        assertThat(response.getLabel()).isEqualTo("손연장 갯수");
+        assertThat(response.getInputType()).isEqualTo("NUMBER");
+        assertThat(response.getRequired()).isTrue();
+        assertThat(response.getIsActive()).isTrue();
+    }
+
+    @Test
+    void getActiveFields_returnsOnlyActiveSorted() {
+        repository.save(ShopMenuInputField.create(
+                1L, "필드B", InputType.TEXT, false, null, null, null, null, null, 1));
+        repository.save(ShopMenuInputField.create(
+                1L, "필드A", InputType.NUMBER, true, null, null, null, null, null, 0));
+        ShopMenuInputField inactive = ShopMenuInputField.create(
+                1L, "비활성", InputType.TEXT, false, null, null, null, null, null, 2);
+        repository.save(inactive);
+        inactive.deactivate();
+        repository.save(inactive);
+
+        List<InputFieldResponse> result = service.getActiveFields(1L);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getLabel()).isEqualTo("필드A");
+        assertThat(result.get(1).getLabel()).isEqualTo("필드B");
+    }
+
+    @Test
+    void update_changesLabel() {
+        ShopMenuInputField saved = repository.save(ShopMenuInputField.create(
+                1L, "갯수", InputType.NUMBER, true,
+                BigDecimal.ONE, BigDecimal.TEN, null, null, null, 0));
+
+        InputFieldResponse response = service.update(saved.getId(),
+                new UpdateInputFieldRequest("수량", null, null, null, null, null, null));
+
+        assertThat(response.getLabel()).isEqualTo("수량");
+    }
+
+    @Test
+    void deactivate_setsIsActiveToFalse() {
+        ShopMenuInputField saved = repository.save(ShopMenuInputField.create(
+                1L, "갯수", InputType.NUMBER, true, null, null, null, null, null, 0));
+
+        service.deactivate(saved.getId());
+
+        ShopMenuInputField found = repository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getIsActive()).isFalse();
+    }
+}

--- a/src/test/java/com/example/easybooking/shop/service/ShopMenuManagementServiceTest.java
+++ b/src/test/java/com/example/easybooking/shop/service/ShopMenuManagementServiceTest.java
@@ -1,0 +1,81 @@
+package com.example.easybooking.shop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.easybooking.shop.ShopMenuReader;
+import com.example.easybooking.shop.ShopMenuWriter;
+import com.example.easybooking.shop.domain.ShopMenu;
+import com.example.easybooking.shop.dto.request.CreateShopMenuRequest;
+import com.example.easybooking.shop.dto.request.UpdateShopMenuRequest;
+import com.example.easybooking.shop.dto.response.ShopMenuResponse;
+import com.example.easybooking.shop.repository.ShopMenuRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ShopMenuManagementServiceTest {
+
+    @Autowired
+    ShopMenuRepository shopMenuRepository;
+
+    ShopMenuManagementService service;
+
+    @BeforeEach
+    void setUp() {
+        shopMenuRepository.deleteAll();
+        ShopMenuReader reader = new ShopMenuReader(shopMenuRepository);
+        ShopMenuWriter writer = new ShopMenuWriter(shopMenuRepository);
+        service = new ShopMenuManagementService(reader, writer);
+    }
+
+    @Test
+    void create_returnsCreatedMenu() {
+        CreateShopMenuRequest request = new CreateShopMenuRequest("젤네일", "기본 젤네일", 0);
+
+        ShopMenuResponse response = service.create(1L, request);
+
+        assertThat(response.getId()).isNotNull();
+        assertThat(response.getShopId()).isEqualTo(1L);
+        assertThat(response.getName()).isEqualTo("젤네일");
+        assertThat(response.getDescription()).isEqualTo("기본 젤네일");
+        assertThat(response.getIsActive()).isTrue();
+    }
+
+    @Test
+    void getActiveMenus_returnsOnlyActiveMenusSorted() {
+        shopMenuRepository.save(ShopMenu.create(1L, "메뉴B", null, true, 1));
+        shopMenuRepository.save(ShopMenu.create(1L, "메뉴A", null, true, 0));
+        shopMenuRepository.save(ShopMenu.create(1L, "비활성", null, false, 2));
+
+        List<ShopMenuResponse> result = service.getActiveMenus(1L);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getName()).isEqualTo("메뉴A");
+        assertThat(result.get(1).getName()).isEqualTo("메뉴B");
+    }
+
+    @Test
+    void update_changesNameAndDescription() {
+        ShopMenu saved = shopMenuRepository.save(ShopMenu.create(1L, "젤네일", "설명", true, 0));
+
+        ShopMenuResponse response = service.update(1L, saved.getId(),
+                new UpdateShopMenuRequest("젤아트", "새 설명", 1));
+
+        assertThat(response.getName()).isEqualTo("젤아트");
+        assertThat(response.getDescription()).isEqualTo("새 설명");
+        assertThat(response.getSortOrder()).isEqualTo(1);
+    }
+
+    @Test
+    void deactivate_setsIsActiveToFalse() {
+        ShopMenu saved = shopMenuRepository.save(ShopMenu.create(1L, "젤네일", null, true, 0));
+
+        service.deactivate(1L, saved.getId());
+
+        ShopMenu found = shopMenuRepository.findById(saved.getId()).orElseThrow();
+        assertThat(found.getIsActive()).isFalse();
+    }
+}

--- a/src/test/java/com/example/easybooking/shop/service/ShopMenuManagementServiceTest.java
+++ b/src/test/java/com/example/easybooking/shop/service/ShopMenuManagementServiceTest.java
@@ -50,7 +50,7 @@ class ShopMenuManagementServiceTest {
         shopMenuRepository.save(ShopMenu.create(1L, "메뉴A", null, true, 0));
         shopMenuRepository.save(ShopMenu.create(1L, "비활성", null, false, 2));
 
-        List<ShopMenuResponse> result = service.getActiveMenus(1L);
+        List<ShopMenuResponse> result = service.getActiveMenus(1L, null);
 
         assertThat(result).hasSize(2);
         assertThat(result.get(0).getName()).isEqualTo("메뉴A");

--- a/src/test/java/com/example/easybooking/shop/service/TagServiceTest.java
+++ b/src/test/java/com/example/easybooking/shop/service/TagServiceTest.java
@@ -1,0 +1,90 @@
+package com.example.easybooking.shop.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.easybooking.shop.domain.ShopMenu;
+import com.example.easybooking.shop.domain.ShopMenuTag;
+import com.example.easybooking.shop.domain.Tag;
+import com.example.easybooking.shop.dto.response.TagResponse;
+import com.example.easybooking.shop.repository.ShopMenuRepository;
+import com.example.easybooking.shop.repository.ShopMenuTagRepository;
+import com.example.easybooking.shop.repository.TagRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class TagServiceTest {
+
+    @Autowired TagRepository tagRepository;
+    @Autowired ShopMenuTagRepository shopMenuTagRepository;
+    @Autowired ShopMenuRepository shopMenuRepository;
+
+    TagService service;
+
+    @BeforeEach
+    void setUp() {
+        shopMenuTagRepository.deleteAll();
+        shopMenuRepository.deleteAll();
+        tagRepository.deleteAll();
+        service = new TagService(tagRepository, shopMenuTagRepository);
+    }
+
+    @Test
+    void createOrGet_createsNewTag() {
+        TagResponse response = service.createOrGet("손관리");
+
+        assertThat(response.getId()).isNotNull();
+        assertThat(response.getName()).isEqualTo("손관리");
+    }
+
+    @Test
+    void createOrGet_returnsExistingTag_whenDuplicate() {
+        TagResponse first = service.createOrGet("손관리");
+        TagResponse second = service.createOrGet("손관리");
+
+        assertThat(second.getId()).isEqualTo(first.getId());
+    }
+
+    @Test
+    void getAllTags_returnsAllTags() {
+        tagRepository.save(Tag.create("손관리"));
+        tagRepository.save(Tag.create("발관리"));
+
+        List<TagResponse> result = service.getAllTags();
+
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void getAllTags_returnsEmptyList_whenNoTags() {
+        List<TagResponse> result = service.getAllTags();
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void addTagToMenu_createsLink() {
+        ShopMenu menu = shopMenuRepository.save(ShopMenu.create(1L, "젤네일", null, true, 0));
+        Tag tag = tagRepository.save(Tag.create("손관리"));
+
+        service.addTagToMenu(menu.getId(), tag.getId());
+
+        assertThat(shopMenuTagRepository.findByShopMenuIdAndTagId(menu.getId(), tag.getId()))
+                .isPresent();
+    }
+
+    @Test
+    void removeTagFromMenu_deletesLink() {
+        ShopMenu menu = shopMenuRepository.save(ShopMenu.create(1L, "젤네일", null, true, 0));
+        Tag tag = tagRepository.save(Tag.create("손관리"));
+        shopMenuTagRepository.save(ShopMenuTag.create(menu.getId(), tag.getId()));
+
+        service.removeTagFromMenu(menu.getId(), tag.getId());
+
+        assertThat(shopMenuTagRepository.findByShopMenuIdAndTagId(menu.getId(), tag.getId()))
+                .isEmpty();
+    }
+}


### PR DESCRIPTION
**Branch**: `feature/jiseob/#99` -> `develop`
**Commits**: 25개 (TDD 기반, 커밋당 단일 논리 단위)

---

## Summary

기존 예약 시스템은 `formDataJson`(비정형 JSON)에 전적으로 의존하여 메뉴 정보를 관리했다.
이로 인해 메뉴별 입력값 검증, 태그 필터링, 스냅샷 보존 등이 불가능했다.

이 PR은 정형화된 메뉴/태그/입력 필드 엔티티를 도입하고, 예약 생성-조회 전 과정에서 구조적 데이터를 사용하도록 변경한다. 기존 `formDataJson` 기반 흐름은 dual-write + fallback으로 호환을 유지한다.

**대안 검토**:
- `formDataJson` 스키마 강제화 -> 기존 데이터 마이그레이션 비용이 크고, 필드별 검증이 어려움
- 새 정형 테이블 도입 + dual-write -> 레거시 호환 유지하면서 점진 전환 가능 (채택)

---

## Changes

1. **ShopMenu / Tag / ShopMenuInputField 도메인 신규 구축** (Phase 1~3)
   - `ShopMenu`, `Tag`, `ShopMenuTag`, `ShopMenuInputField` 엔티티 + CRUD API
   - 태그 기반 메뉴 필터링 (OR 로직)
   - 입력 필드 타입별 검증 (NUMBER: min/max/step, TEXT: maxLength)
   - Flyway V4: `shop_services` -> `shop_menus` 계열 리네이밍 + `key` 컬럼 제거

2. **예약-메뉴 연결 및 입력값 저장** (Phase 4)
   - `ReservationMenuItem`, `ReservationMenuInputValue` 엔티티
   - 예약 생성 시 메뉴 선택 + 입력값 검증/저장 (shop/active 검증, required/범위/step/타입 검증)
   - Dual-write: `formDataJson` + 새 테이블 동시 저장, 트랜잭션 정합성 보장

3. **예약 조회 시 메뉴/입력값 응답** (Phase 5)
   - `ReservationMenuItemReader`, `ReservationMenuInputValueReader` 추가
   - `ReservationDetailResponse`에 `menus` 필드 추가 (메뉴별 inputValues 중첩)
   - `reservation_menu_items` 없는 기존 예약은 `formDataJson` fallback

---

## Test plan

- TDD plan: [`docs/issues/#99/04-tdd/plan.md`](docs/issues/#99/04-tdd/plan.md)

### 확인한 테스트 (Phase별)

- [x] Phase 1: ShopMenu 엔티티 JPA 매핑, UNIQUE 제약, Reader/Writer, CRUD API (7건)
- [x] Phase 2: Tag 엔티티, ShopMenuTag, 태그 필터링(OR), TagService CRUD (7건)
- [x] Phase 3: ShopMenuInputField 엔티티, 타입별 검증(NUMBER/TEXT), CRUD API (6건)
- [x] Phase 4-A/B: ReservationMenuItem/InputValue 엔티티, JPA 매핑, UNIQUE 제약 (4건)
- [x] Phase 4-C: 메뉴 선택 로직 (스냅샷, 빈 리스트, 다른 샵, 비활성 메뉴) (5건)
- [x] Phase 4-D: 입력값 저장 (required, min/max, step, maxLength, 타입 불일치, 필드 소속) (7건)
- [x] Phase 4-E: Dual-write (formDataJson 동시 저장, 트랜잭션 롤백) (3건)
- [x] Phase 5-A: 조회 응답 (메뉴+입력값 포함, formDataJson fallback, 중첩 구조) (3건)

### 엣지 케이스 / 회귀 포인트

- NUMBER 필드 경계값 (min/max 정확히 일치하는 값)
- step 검증: minValue 기준 offset 계산, stepValue=null 시 skip
- TEXT maxLength=null 시 검증 skip
- 원본 메뉴 이름 변경 후 스냅샷 보존 (통합 테스트)
- Dual-write 실패 시 전체 롤백 (formDataJson 포함)
- 기존 예약(menu_items 없음) 조회 시 fallback 정상 동작

---

## Risks & Rollback

| 위험 요소 | 영향 | 완화 전략 |
|-----------|------|----------|
| Flyway V4 마이그레이션 실패 | 테이블 리네이밍 실패 시 기존 기능 영향 | V4는 `RENAME TABLE`만 사용, 롤백 SQL 준비 가능 |
| `formDataJson` 제거 시점 미정 | Dual-write 유지 비용 | 별도 이슈로 분리 (Non-goal 명시) |
| N+1 쿼리 (조회 시 메뉴/입력값) | 예약 목록 조회 성능 | 현재 상세 조회에만 적용, 목록 조회는 미적용 |
| 새 엔티티 CRUD API 인증/인가 | 비인가 접근 가능성 | 기존 `@RequireAuthenticatedUser` 패턴 적용 |

**롤백**: 브랜치 revert 시 Flyway V4를 역방향 마이그레이션(V5로 rollback SQL)하면 원복 가능. Dual-write 구조이므로 새 테이블 제거해도 `formDataJson` 기반 기존 흐름은 영향 없음.

--- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-select menu in reservations with per-item additional inputs (number/text) and dual-write support; reservation details include menu/item inputs.
  * Tag-based menu filtering and full menu management (create, update, deactivate, list with tags).
  * Input field management for menus with validation (range, step, max length).

* **Documentation**
  * Added design, phased rollout, and TDD planning documents covering implementation and migration.

* **Tests**
  * Extensive unit/integration tests for menus, input fields, tags, reservations, and DB mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->