### PR TITLE
refactor : formData 제거 및 새로운 스키마 적용

### DIFF
--- a/src/main/java/com/example/easybooking/reservation/domain/Reservation.java
+++ b/src/main/java/com/example/easybooking/reservation/domain/Reservation.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -69,10 +68,6 @@ public class Reservation {
     private String rejectionReason;
     private String confirmationMessage;
 
-    @Lob
-    @Column(nullable = false, columnDefinition = "LONGTEXT")
-    private String formDataJson;
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Status status;     // 예약 상태
@@ -90,7 +85,6 @@ public class Reservation {
             Long customerId,
             LocalDate date,
             LocalTime time,
-            String formDataJson,
             List<String> designImageURLs) {
 
         Reservation reservation = new Reservation();
@@ -101,7 +95,6 @@ public class Reservation {
         reservation.date = date;
         reservation.time = time;
         reservation.startAt = LocalDateTime.of(date, time);
-        reservation.formDataJson = formDataJson;
         reservation.designImageURLs = designImageURLs;
         reservation.status = Status.PENDING;  // 초기 상태 : 대기
         reservation.createdAt = LocalDateTime.now();

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationCreateRequest.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationCreateRequest.java
@@ -1,17 +1,17 @@
 package com.example.easybooking.reservation.dto;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
 import lombok.Data;
 
 @Data
 public class ReservationCreateRequest {
     private Long shopId;
     private Long staffId;
-
-    // 레거시 폼 데이터 (dual-write 호환)
-    private Map<String, String> formData;
-
-    // 신규: 메뉴 선택 (nullable — 없으면 레거시 모드)
+    private LocalDate date;
+    private LocalTime time;
+    private String requirements;
+    private List<String> imageUrls;
     private List<MenuSelectionRequest> menuSelections;
 }

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationCustomerResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationCustomerResponse.java
@@ -1,17 +1,10 @@
 package com.example.easybooking.reservation.dto;
 
-import com.example.easybooking.form.FormParsingUtil;
 import com.example.easybooking.reservation.domain.Reservation;
-import com.example.easybooking.shop.ShopReader;
-import com.example.easybooking.shop.domain.Shop;
-import com.example.easybooking.user.UserReader;
-import com.example.easybooking.user.domain.User;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
-
 import lombok.Builder;
 import lombok.Data;
 
@@ -30,50 +23,13 @@ public class ReservationCustomerResponse {
     private String confirmationMessage;  // 전달 사항 (확정 시)
     private LocalDateTime createdAt;
 
-    private String part;
-    private String removal;
-    private String requests;
-
-    private Integer extendCount;
-    private Integer wrappingCount;
-
-    private String extendStatus;    // 연장 유/무 (화면 표시용)
-    private String wrappingStatus;  // 래핑 유/무 (화면 표시용)
-
-    public static ReservationCustomerResponse from(
-            Reservation reservation,
-            UserReader userReader,
-            ShopReader shopReader,
-            Map<String, String> formData
-    ) {
-        // 1. 고객 이름 조회
-        User customer = userReader.read(reservation.getCustomerId());
-        String customerName = customer.getName();
-
-        // 2. 샵 이름 조회
-        Shop shop = shopReader.read(reservation.getShopId());
-        String shopName = shop.getBusinessName();
-        return from(reservation, customerName, shopName, formData);
-    }
-
     public static ReservationCustomerResponse from(
             Reservation reservation,
             String customerName,
-            String shopName,
-            Map<String, String> formData
+            String shopName
     ) {
         List<String> photoUrls = reservation.getDesignImageURLs();
         int photoCount = photoUrls.size();
-
-        String part = formData.get("part");
-        String removal = formData.get("removal");
-        String requests = formData.get("requests");
-
-        Integer extendCount = FormParsingUtil.parseSafeInteger(formData.get("extend"));
-        Integer wrappingCount = FormParsingUtil.parseSafeInteger(formData.get("wrapping"));
-
-        String extendStatus = (extendCount != null && extendCount > 0) ? "유" : "무";
-        String wrappingStatus = (wrappingCount != null && wrappingCount > 0) ? "유" : "무";
 
         return ReservationCustomerResponse.builder()
                 .id(reservation.getId())
@@ -87,13 +43,6 @@ public class ReservationCustomerResponse {
                 .rejectionReason(reservation.getRejectionReason())
                 .confirmationMessage(reservation.getConfirmationMessage())
                 .createdAt(reservation.getCreatedAt())
-                .part(part)
-                .removal(removal)
-                .requests(requests)
-                .extendCount(extendCount)
-                .wrappingCount(wrappingCount)
-                .extendStatus(extendStatus)
-                .wrappingStatus(wrappingStatus)
                 .build();
     }
 }

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationDetailResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationDetailResponse.java
@@ -29,16 +29,6 @@ public class ReservationDetailResponse {
     private List<String> photoUrls;
     private int photoCount;
 
-    private String part;
-    private String removal;
-    private String requests;
-
-    private Integer extendCount;
-    private Integer wrappingCount;
-
-    private String extendStatus;
-    private String wrappingStatus;
-
     private List<ReservationMenuItemResponse> menus;
 }
 

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationOwnerResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationOwnerResponse.java
@@ -1,9 +1,6 @@
 package com.example.easybooking.reservation.dto;
 
-import com.example.easybooking.form.FormParsingUtil;
 import com.example.easybooking.reservation.domain.Reservation;
-import com.example.easybooking.user.UserReader;
-import com.example.easybooking.user.domain.User;
 import lombok.Builder;
 import lombok.Data;
 
@@ -11,7 +8,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
 
 @Data
 @Builder
@@ -28,46 +24,12 @@ public class ReservationOwnerResponse {
     private String confirmationMessage;  // 전달 사항 (확정 시)
     private LocalDateTime createdAt;
 
-    private String part;
-    private String removal;
-    private String requests;
-
-    private Integer extendCount;
-    private Integer wrappingCount;
-
-    private String extendStatus;    // 연장 유/무 (화면 표시용)
-    private String wrappingStatus;  // 래핑 유/무 (화면 표시용)
-
-    public static ReservationOwnerResponse from(
-            Reservation reservation,
-            UserReader userReader,
-            Map<String, String> formData
-    ) {
-        // 1. 고객 정보 조회
-        User customer = userReader.read(reservation.getCustomerId());
-        return from(reservation, customer.getName(), customer.getPhoneNumber(), formData);
-    }
-
     public static ReservationOwnerResponse from(
             Reservation reservation,
             String customerName,
-            String customerPhone,
-            Map<String, String> formData
+            String customerPhone
     ) {
-
-        // 사진 URL 목록 조회
         List<String> photoUrls = reservation.getDesignImageURLs();
-
-        // 폼 데이터에서 상세 필드 추출
-        String part = formData.get("part");
-        String removal = formData.get("removal");
-        String requests = formData.get("requests");
-
-        Integer extendCount = FormParsingUtil.parseSafeInteger(formData.get("extend"));
-        Integer wrappingCount = FormParsingUtil.parseSafeInteger(formData.get("wrapping"));
-
-        String extendStatus = (extendCount != null && extendCount > 0) ? "유" : "무";
-        String wrappingStatus = (wrappingCount != null && wrappingCount > 0) ? "유" : "무";
 
         return ReservationOwnerResponse.builder()
                 .id(reservation.getId())
@@ -81,14 +43,6 @@ public class ReservationOwnerResponse {
                 .rejectionReason(reservation.getRejectionReason())
                 .confirmationMessage(reservation.getConfirmationMessage())
                 .createdAt(reservation.getCreatedAt())
-
-                .part(part)
-                .removal(removal)
-                .requests(requests)
-                .extendCount(extendCount)
-                .wrappingCount(wrappingCount)
-                .extendStatus(extendStatus)
-                .wrappingStatus(wrappingStatus)
                 .build();
     }
 }

--- a/src/main/java/com/example/easybooking/reservation/dto/ReservationResponse.java
+++ b/src/main/java/com/example/easybooking/reservation/dto/ReservationResponse.java
@@ -1,10 +1,10 @@
 package com.example.easybooking.reservation.dto;
 
 import com.example.easybooking.reservation.domain.Reservation;
-import lombok.Data;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
+import lombok.Data;
 
 @Data
 public class ReservationResponse {
@@ -17,12 +17,6 @@ public class ReservationResponse {
     private String customerName;
     private Integer photoCount;
 
-    private String part;
-    private String removal;
-    private Integer extendCount;
-    private Integer wrappingCount;
-    private String extendStatus;     // 연장 유/무 (화면 표시용)
-    private String wrappingStatus;   // 래핑 유/무 (화면 표시용)
     private List<String> photoUrls;
     private String requests;
 
@@ -31,10 +25,6 @@ public class ReservationResponse {
             Reservation entity,
             String customerName,
             Integer photoCount,
-            String part,
-            String removal,
-            Integer extendCount,
-            Integer wrappingCount,
             List<String> photoUrls,
             String requests
     ) {
@@ -46,16 +36,7 @@ public class ReservationResponse {
         this.customerName = customerName;
         this.photoCount = photoCount;
 
-        this.part = part;
-        this.removal = removal;
         this.requests = requests;
         this.photoUrls = photoUrls;
-
-        this.extendCount = extendCount;
-        this.wrappingCount = wrappingCount;
-
-        // 수량을 기반으로 '유/무' 상태로 바꾸기
-        this.extendStatus = (extendCount != null && extendCount > 0) ? "유" : "무";
-        this.wrappingStatus = (wrappingCount != null && wrappingCount > 0) ? "유" : "무";
     }
 }

--- a/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
+++ b/src/main/java/com/example/easybooking/reservation/service/ReservationService.java
@@ -5,7 +5,6 @@ import com.example.easybooking.errors.errorcode.AuthErrorCode;
 import com.example.easybooking.errors.errorcode.ReservationErrorCode;
 import com.example.easybooking.errors.exception.AuthException;
 import com.example.easybooking.errors.exception.ReservationException;
-import com.example.easybooking.form.FormParsingUtil;
 import com.example.easybooking.reservation.ReservationMenuInputValueReader;
 import com.example.easybooking.reservation.ReservationMenuItemReader;
 import com.example.easybooking.reservation.ReservationReader;
@@ -36,8 +35,6 @@ import com.example.easybooking.staff.exception.StaffIdNotFoundException;
 import com.example.easybooking.user.UserReader;
 import com.example.easybooking.user.domain.User;
 import com.example.easybooking.user.domain.UserType;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -89,28 +86,15 @@ public class ReservationService {
         Shop shop = shopReader.read(shopId);
         Long ownerUserId = shop.getOwnerId();
 
-        Map<String, String> formData = request.getFormData();
-        String formDataJson;
-
-        try {
-            formDataJson = objectMapper.writeValueAsString(formData);
-        } catch (JsonProcessingException e) {
-            throw new ReservationException(ReservationErrorCode.INVALID_FORM_JSON);
-        }
-
-        // 날짜 추출 및 변환
-        String dateString = formData.get("date");
-        if (dateString == null) {
+        LocalDate date = request.getDate();
+        if (date == null) {
             throw new ReservationException(ReservationErrorCode.REQUIRED_DATE_MISSING);
         }
-        LocalDate date = LocalDate.parse(dateString);
 
-        // 시간 추출 및 변환
-        String timeString = formData.get("time");
-        if (timeString == null) {
+        LocalTime time = request.getTime();
+        if (time == null) {
             throw new ReservationException(ReservationErrorCode.REQUIRED_TIME_MISSING);
         }
-        LocalTime time = LocalTime.parse(timeString);
 
         if (staffId == null) {
             throw new ReservationException(ReservationErrorCode.REQUIRED_STAFF_ID_MISSING);
@@ -124,54 +108,14 @@ public class ReservationService {
             throw new ReservationException(ReservationErrorCode.STAFF_NOT_FOUND);
         }
 
-//        // 예약 가능 시간 검증
-//        List<Reservation> existingReservation =
-//                reservationReader.findByShopIdAndDateForUpdate(shopId, date);
-//
-//        List<LocalTime> bookedTimes = existingReservation.stream()
-//                .filter(r -> r.getStatus() != Reservation.Status.CANCELED &&
-//                        r.getStatus() != Reservation.Status.REJECTED)
-//                .map(Reservation::getTime)
-//                .collect(Collectors.toList());
-//
-//        if (bookedTimes.contains(time)) {
-//            log.warn("중복 예약 시도 감지: ShopId={}, Date={}, Time={}", shopId, date, time);
-//            throw new ReservationException(ReservationErrorCode.TIME_SLOT_ALREADY_BOOKED);
-//        }
-
-        // 디자인 사진 URL 추출
-        String photoJsonString = formData.get("photo");
-        List<String> designImageURLs;
-
-        if (photoJsonString == null || photoJsonString.trim().isEmpty()) {
-            designImageURLs = Collections.emptyList();
-        } else {
-            try {
-                designImageURLs = objectMapper.readValue(photoJsonString, new TypeReference<List<String>>() {
-                });
-            } catch (JsonProcessingException e) {
-                throw new ReservationException(ReservationErrorCode.INVALID_PHOTO_JSON);
-            }
-        }
+        String requests = request.getRequirements();
+        List<String> designImageURLs = request.getImageUrls() == null
+                ? Collections.emptyList()
+                : List.copyOf(request.getImageUrls());
 
         User customer = userReader.read(customerUserId);
         String customerName = customer.getName();
         int photoCount = designImageURLs.size();
-
-        // 폼 데이터에서 상세 필드값 추출
-        String part = formData.get("part");
-        String removal = formData.get("removal");
-        String requests = formData.get("requests");
-
-        Integer extendCount;
-        Integer wrappingCount;
-
-        try {
-            extendCount = FormParsingUtil.parseSafeInteger(formData.get("extend"));
-            wrappingCount = FormParsingUtil.parseSafeInteger(formData.get("wrapping"));
-        } catch (NumberFormatException e) {
-            throw new ReservationException(ReservationErrorCode.INVALID_NUMBER_FORMAT);
-        }
 
         validateTimeIsOn10MinuteBoundary(time);
 
@@ -181,14 +125,12 @@ public class ReservationService {
                 customerUserId,
                 date,
                 time,
-                formDataJson,
                 designImageURLs
         );
         newReservation.setStaffId(staffId);
 
         Reservation savedReservation = reservationWriter.save(newReservation);
 
-        // Dual-write: 메뉴 선택이 있으면 새 테이블에도 저장
         List<MenuSelectionRequest> menuSelections = request.getMenuSelections();
         if (menuSelections != null && !menuSelections.isEmpty()) {
             List<Long> menuIds = menuSelections.stream()
@@ -223,10 +165,6 @@ public class ReservationService {
                 savedReservation,
                 customerName,
                 photoCount,
-                part,
-                removal,
-                extendCount,
-                wrappingCount,
                 designImageURLs,
                 requests);
     }
@@ -341,16 +279,6 @@ public class ReservationService {
         // TODO: 고객에게 거절 알림
     }
 
-    private Map<String, String> parseFormData(Reservation reservation) {
-        try {
-            return objectMapper.readValue(reservation.getFormDataJson(), new TypeReference<Map<String, String>>() {
-            });
-        } catch (JsonProcessingException e) {
-            log.error("Reservation ID {}의 formDataJson 파싱 오류", reservation.getId(), e);
-            throw new ReservationException(ReservationErrorCode.INVALID_FORM_JSON, "예약 상세 정보 파싱에 실패했습니다.");
-        }
-    }
-
     /**
      * 예약 상세 조회 (reservationId) - 인증 필요 - 해당 예약의 고객(customerId) 또는 점주(ownerUserId)만 조회 가능
      */
@@ -365,17 +293,6 @@ public class ReservationService {
 
         User customer = userReader.read(reservation.getCustomerId());
         Shop shop = shopReader.read(reservation.getShopId());
-
-        Map<String, String> formData = parseFormData(reservation);
-
-        String part = formData.get("part");
-        String removal = formData.get("removal");
-        String requests = formData.get("requests");
-
-        Integer extendCount = FormParsingUtil.parseSafeInteger(formData.get("extend"));
-        Integer wrappingCount = FormParsingUtil.parseSafeInteger(formData.get("wrapping"));
-        String extendStatus = (extendCount != null && extendCount > 0) ? "유" : "무";
-        String wrappingStatus = (wrappingCount != null && wrappingCount > 0) ? "유" : "무";
 
         List<String> photoUrls = reservation.getDesignImageURLs();
 
@@ -395,13 +312,6 @@ public class ReservationService {
                 .confirmationMessage(reservation.getConfirmationMessage())
                 .photoUrls(photoUrls)
                 .photoCount(photoUrls != null ? photoUrls.size() : 0)
-                .part(part)
-                .removal(removal)
-                .requests(requests)
-                .extendCount(extendCount)
-                .wrappingCount(wrappingCount)
-                .extendStatus(extendStatus)
-                .wrappingStatus(wrappingStatus)
                 .menus(menus)
                 .build();
     }
@@ -466,9 +376,8 @@ public class ReservationService {
 
         return reservations.stream()
                 .map(r -> {
-                    Map<String, String> formData = parseFormData(r);
                     String shopName = shopNameById.get(r.getShopId());
-                    return ReservationCustomerResponse.from(r, customerName, shopName, formData);
+                    return ReservationCustomerResponse.from(r, customerName, shopName);
                 })
                 .toList();
     }
@@ -501,10 +410,8 @@ public class ReservationService {
 
         return reservations.stream()
                 .map(r -> {
-                    Map<String, String> formData = parseFormData(r);
-
                     User customer = userById.get(r.getCustomerId());
-                    return ReservationOwnerResponse.from(r, customer.getName(), customer.getPhoneNumber(), formData);
+                    return ReservationOwnerResponse.from(r, customer.getName(), customer.getPhoneNumber());
                 })
                 .toList();
     }
@@ -546,8 +453,7 @@ public class ReservationService {
 
         return reservations.stream()
                 .map(r -> {
-                    Map<String, String> formData = parseFormData(r);
-                    return ReservationCustomerResponse.from(r, customerName, shopName, formData);
+                    return ReservationCustomerResponse.from(r, customerName, shopName);
                 })
                 .toList();
     }
@@ -576,11 +482,7 @@ public class ReservationService {
 
         return reservations.stream()
                 .map(r -> {
-                    // 🌟 Service에서 JSON 파싱만 수행
-                    Map<String, String> formData = parseFormData(r);
-
-                    // 🌟 DTO.from() 호출 시 파싱된 데이터를 함께 전달
-                    return ReservationOwnerResponse.from(r, customerName, customerPhone, formData);
+                    return ReservationOwnerResponse.from(r, customerName, customerPhone);
                 })
                 .toList();
     }

--- a/src/main/resources/db/migration/V6__drop_reservations_form_data_json.sql
+++ b/src/main/resources/db/migration/V6__drop_reservations_form_data_json.sql
@@ -1,0 +1,2 @@
+ALTER TABLE reservations
+    DROP COLUMN form_data_json;

--- a/src/test/java/com/example/easybooking/ReservationChatPublishIntegrationTest.java
+++ b/src/test/java/com/example/easybooking/ReservationChatPublishIntegrationTest.java
@@ -20,8 +20,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -73,22 +74,13 @@ public class ReservationChatPublishIntegrationTest {
                 .getId();
 
         // given: reservation request
-        Map<String, String> formData = new HashMap<>();
-        formData.put("name", "ascsc");
-        formData.put("phone", "01095302336");
-        formData.put("date", "2025-11-12");
-        formData.put("time", "17:10");
-        formData.put("removal", "예");
-        formData.put("part", "손");
-        formData.put("wrapping", "0");
-        formData.put("extend", "0"); // parseSafeInteger 안전장치
-        formData.put("photo", "[\"KakaoTalk_20250511_191324465.jpg\",\"부경대 로고 2.jfif\"]");
-        formData.put("requests", "cscscsc");
-
         ReservationCreateRequest req = new ReservationCreateRequest();
         req.setShopId(shopId);
         req.setStaffId(staffId);
-        req.setFormData(formData);
+        req.setDate(LocalDate.of(2025, 11, 12));
+        req.setTime(LocalTime.of(17, 10));
+        req.setRequirements("cscscsc");
+        req.setImageUrls(List.of("KakaoTalk_20250511_191324465.jpg", "부경대 로고 2.jfif"));
 
         // when
         ReservationResponse res = reservationService.createReservation(req, customer.getId());

--- a/src/test/java/com/example/easybooking/availability/presentation/AvailabilityControllerIntegrationTest.java
+++ b/src/test/java/com/example/easybooking/availability/presentation/AvailabilityControllerIntegrationTest.java
@@ -298,9 +298,7 @@ class AvailabilityControllerIntegrationTest {
                 fixture.ownerId(),
                 fixture.ownerId() + 1000,
                 LocalDate.of(2026, 2, 16),
-                LocalTime.of(10, 0),
-                "{}",
-                List.of()
+                LocalTime.of(10, 0), List.of()
         );
         reservation.setStaffId(fixture.staffId());
         reservation.confirm("확정", 60);
@@ -357,3 +355,4 @@ class AvailabilityControllerIntegrationTest {
     private record Fixture(Long ownerId, Long shopId, Long staffId) {
     }
 }
+

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationCreateStartAtDualWriteRedTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationCreateStartAtDualWriteRedTest.java
@@ -32,9 +32,7 @@ class ReservationCreateStartAtDualWriteRedTest {
                 1L,
                 2L,
                 date,
-                time,
-                "{\"form\":{}}",
-                List.of()
+                time, List.of()
         );
 
         Reservation saved = reservationRepository.save(reservation);
@@ -45,4 +43,5 @@ class ReservationCreateStartAtDualWriteRedTest {
         assertThat(found.getStartAt()).isEqualTo(expectedStartAt);
     }
 }
+
 

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationDurationMinutesJpaMappingTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationDurationMinutesJpaMappingTest.java
@@ -27,9 +27,7 @@ class ReservationDurationMinutesJpaMappingTest {
                 1L,
                 2L,
                 LocalDate.of(2026, 2, 5),
-                LocalTime.of(14, 0),
-                "{\"form\":{}}",
-                List.of()
+                LocalTime.of(14, 0), List.of()
         );
         reservation.setDurationMinutes(60);
 
@@ -41,4 +39,5 @@ class ReservationDurationMinutesJpaMappingTest {
         assertThat(found.getDurationMinutes()).isEqualTo(60);
     }
 }
+
 

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuInputValueJpaMappingTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuInputValueJpaMappingTest.java
@@ -29,8 +29,7 @@ class ReservationMenuInputValueJpaMappingTest {
     void reservationMenuInputValue_isMappedToReservationMenuInputValuesTable() {
         Reservation reservation = reservationRepository.save(Reservation.createReservation(
                 1L, 1L, 2L,
-                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0),
-                "{}", List.of()));
+                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0), List.of()));
 
         ReservationMenuItem menuItem = menuItemRepository.saveAndFlush(
                 ReservationMenuItem.create(reservation.getId(), 10L, "젤네일", null, 0));
@@ -58,3 +57,4 @@ class ReservationMenuInputValueJpaMappingTest {
         assertThat(found.getValueText()).isNull();
     }
 }
+

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuInputValueUniqueConstraintTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuInputValueUniqueConstraintTest.java
@@ -30,8 +30,7 @@ class ReservationMenuInputValueUniqueConstraintTest {
     void save_throwsException_whenDuplicateMenuItemIdAndFieldId() {
         Reservation reservation = reservationRepository.save(Reservation.createReservation(
                 1L, 1L, 2L,
-                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0),
-                "{}", List.of()));
+                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0), List.of()));
 
         ReservationMenuItem menuItem = menuItemRepository.saveAndFlush(
                 ReservationMenuItem.create(reservation.getId(), 10L, "젤네일", null, 0));
@@ -49,8 +48,7 @@ class ReservationMenuInputValueUniqueConstraintTest {
     void save_allowsSameFieldInDifferentMenuItems() {
         Reservation reservation = reservationRepository.save(Reservation.createReservation(
                 1L, 1L, 2L,
-                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0),
-                "{}", List.of()));
+                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0), List.of()));
 
         ReservationMenuItem item1 = menuItemRepository.saveAndFlush(
                 ReservationMenuItem.create(reservation.getId(), 10L, "젤네일", null, 0));
@@ -64,3 +62,4 @@ class ReservationMenuInputValueUniqueConstraintTest {
         // 다른 menuItem에 동일 fieldId -> 허용
     }
 }
+

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuItemJpaMappingTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuItemJpaMappingTest.java
@@ -27,9 +27,7 @@ class ReservationMenuItemJpaMappingTest {
                 1L,
                 2L,
                 LocalDate.of(2026, 2, 11),
-                LocalTime.of(14, 0),
-                "{\"form\":{}}",
-                List.of()
+                LocalTime.of(14, 0), List.of()
         );
         Reservation savedReservation = reservationRepository.save(reservation);
 
@@ -53,3 +51,4 @@ class ReservationMenuItemJpaMappingTest {
         assertThat(found.getSortOrder()).isEqualTo(0);
     }
 }
+

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuItemSnapshotIntegrationTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuItemSnapshotIntegrationTest.java
@@ -34,8 +34,7 @@ class ReservationMenuItemSnapshotIntegrationTest {
         // 예약 + 메뉴 선택 (스냅샷 = "젤네일")
         Reservation reservation = reservationRepository.save(Reservation.createReservation(
                 1L, 1L, 2L,
-                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0),
-                "{}", List.of()));
+                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0), List.of()));
         ReservationMenuItem saved = menuItemRepository.saveAndFlush(
                 ReservationMenuItem.create(reservation.getId(), menu.getId(), menu.getName(), null, 0));
 
@@ -48,3 +47,4 @@ class ReservationMenuItemSnapshotIntegrationTest {
         assertThat(found.getMenuNameSnapshot()).isEqualTo("젤네일");
     }
 }
+

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuItemUniqueConstraintTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationMenuItemUniqueConstraintTest.java
@@ -25,8 +25,7 @@ class ReservationMenuItemUniqueConstraintTest {
     void save_throwsException_whenDuplicateReservationIdAndShopMenuId() {
         Reservation saved = reservationRepository.save(Reservation.createReservation(
                 1L, 1L, 2L,
-                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0),
-                "{}", List.of()));
+                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0), List.of()));
 
         reservationMenuItemRepository.saveAndFlush(
                 ReservationMenuItem.create(saved.getId(), 10L, "젤네일", null, 0));
@@ -40,12 +39,10 @@ class ReservationMenuItemUniqueConstraintTest {
     void save_allowsSameMenuInDifferentReservations() {
         Reservation r1 = reservationRepository.save(Reservation.createReservation(
                 1L, 1L, 2L,
-                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0),
-                "{}", List.of()));
+                LocalDate.of(2026, 2, 11), LocalTime.of(14, 0), List.of()));
         Reservation r2 = reservationRepository.save(Reservation.createReservation(
                 1L, 1L, 3L,
-                LocalDate.of(2026, 2, 11), LocalTime.of(15, 0),
-                "{}", List.of()));
+                LocalDate.of(2026, 2, 11), LocalTime.of(15, 0), List.of()));
 
         reservationMenuItemRepository.saveAndFlush(
                 ReservationMenuItem.create(r1.getId(), 10L, "젤네일", null, 0));
@@ -54,3 +51,4 @@ class ReservationMenuItemUniqueConstraintTest {
         // 다른 예약에 동일 메뉴 -> 허용
     }
 }
+

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationStaffIdJpaMappingTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationStaffIdJpaMappingTest.java
@@ -27,9 +27,7 @@ class ReservationStaffIdJpaMappingTest {
                 1L,
                 2L,
                 LocalDate.of(2026, 2, 5),
-                LocalTime.of(14, 0),
-                "{\"form\":{}}",
-                List.of()
+                LocalTime.of(14, 0), List.of()
         );
         reservation.setStaffId(1L);
 
@@ -41,4 +39,5 @@ class ReservationStaffIdJpaMappingTest {
         assertThat(found.getStaffId()).isEqualTo(1L);
     }
 }
+
 

--- a/src/test/java/com/example/easybooking/reservation/domain/ReservationStartAtJpaMappingTest.java
+++ b/src/test/java/com/example/easybooking/reservation/domain/ReservationStartAtJpaMappingTest.java
@@ -28,9 +28,7 @@ class ReservationStartAtJpaMappingTest {
                 1L,
                 2L,
                 LocalDate.of(2026, 2, 5),
-                LocalTime.of(14, 0),
-                "{\"form\":{}}",
-                List.of()
+                LocalTime.of(14, 0), List.of()
         );
         LocalDateTime startAt = LocalDateTime.of(2026, 2, 5, 14, 0);
         reservation.setStartAt(startAt);
@@ -43,4 +41,5 @@ class ReservationStartAtJpaMappingTest {
         assertThat(found.getStartAt()).isEqualTo(startAt);
     }
 }
+
 

--- a/src/test/java/com/example/easybooking/reservation/presentation/ReservationCreateRequestContractIntegrationTest.java
+++ b/src/test/java/com/example/easybooking/reservation/presentation/ReservationCreateRequestContractIntegrationTest.java
@@ -1,0 +1,182 @@
+package com.example.easybooking.reservation.presentation;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.easybooking.auth.domain.AuthenticatedUser;
+import com.example.easybooking.shop.domain.Shop;
+import com.example.easybooking.shop.dto.request.CreateShopRequest;
+import com.example.easybooking.shop.repository.ShopRepository;
+import com.example.easybooking.staff.domain.Staff;
+import com.example.easybooking.staff.repository.StaffRepository;
+import com.example.easybooking.user.domain.User;
+import com.example.easybooking.user.domain.UserType;
+import com.example.easybooking.user.domain.repository.UserRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@Transactional
+class ReservationCreateRequestContractIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    ShopRepository shopRepository;
+
+    @Autowired
+    StaffRepository staffRepository;
+
+    private Long shopId;
+    private Long staffId;
+
+    @BeforeEach
+    void setUp() {
+        User owner = userRepository.save(User.createUser(
+                "owner-" + UUID.randomUUID(),
+                "owner",
+                "010-1111-1111",
+                UserType.OWNER
+        ));
+        User customer = userRepository.save(User.createUser(
+                "customer-" + UUID.randomUUID(),
+                "customer",
+                "010-2222-2222",
+                UserType.CUSTOMER
+        ));
+
+        Shop shop = shopRepository.save(Shop.create(owner.getId(), CreateShopRequest.builder()
+                .businessName("shop")
+                .address("seoul")
+                .businessNumber("123")
+                .build()));
+        Staff staff = staffRepository.save(Staff.create(shop.getId(), "default-staff"));
+        this.shopId = shop.getId();
+        this.staffId = staff.getId();
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(
+                new AuthenticatedUser(customer.getId(), "ROLE_USER"),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        ));
+        SecurityContextHolder.setContext(context);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("레거시 formData 요청만으로는 예약 생성이 실패해야 한다")
+    void createReservation_withFormDataOnly_returns4xx() throws Exception {
+        Map<String, Object> formData = new HashMap<>();
+        formData.put("date", "2026-03-15");
+        formData.put("time", "10:00");
+        formData.put("requests", "legacy");
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("shopId", shopId);
+        payload.put("staffId", staffId);
+        payload.put("formData", formData);
+
+        mockMvc.perform(post("/api/reservations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    @DisplayName("예약 생성 요청에서 date 누락 시 400을 반환한다")
+    void createReservation_withoutDate_returns400() throws Exception {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("shopId", shopId);
+        payload.put("staffId", staffId);
+
+        mockMvc.perform(post("/api/reservations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("REQUIRED_DATE_MISSING"));
+    }
+
+    @Test
+    @DisplayName("예약 생성 요청에서 time 누락 시 400을 반환한다")
+    void createReservation_withoutTime_returns400() throws Exception {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("shopId", shopId);
+        payload.put("staffId", staffId);
+        payload.put("date", "2026-03-15");
+
+        mockMvc.perform(post("/api/reservations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("REQUIRED_TIME_MISSING"));
+    }
+
+    @Test
+    @DisplayName("신규 필드(date/time/requirements/imageUrls)로 예약 생성이 성공한다")
+    void createReservation_withNewFields_returns201() throws Exception {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("shopId", shopId);
+        payload.put("staffId", staffId);
+        payload.put("date", "2026-03-16");
+        payload.put("time", "10:00");
+        payload.put("requirements", "short nails");
+        payload.put("imageUrls", List.of("https://example.com/a.jpg", "https://example.com/b.jpg"));
+        payload.put("menuSelections", List.of());
+
+        mockMvc.perform(post("/api/reservations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.date").value("2026-03-16"))
+                .andExpect(jsonPath("$.time").value("10:00:00"))
+                .andExpect(jsonPath("$.requests").value("short nails"))
+                .andExpect(jsonPath("$.photoCount").value(2));
+    }
+
+    @Test
+    @DisplayName("예약 생성 요청에서 time 형식 오류는 400(INVALID_PARAMETER)으로 매핑된다")
+    void createReservation_withInvalidTimeFormat_returns400() throws Exception {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("shopId", shopId);
+        payload.put("staffId", staffId);
+        payload.put("date", "2026-03-16");
+        payload.put("time", "25:61");
+
+        mockMvc.perform(post("/api/reservations")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(payload)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_PARAMETER"));
+    }
+}

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceConfirmOverlapRollbackIntegrationTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceConfirmOverlapRollbackIntegrationTest.java
@@ -61,8 +61,7 @@ class ReservationServiceConfirmOverlapRollbackIntegrationTest {
         Reservation reservation = Reservation.createReservation(
                 100L, ownerId, 200L,
                 LocalDate.of(2026, 2, 5),
-                LocalTime.of(14, 0),
-                "{}", List.of()
+                LocalTime.of(14, 0), List.of()
         );
         reservation.setStaffId(staffId);
 
@@ -105,8 +104,7 @@ class ReservationServiceConfirmOverlapRollbackIntegrationTest {
         Reservation reservation = Reservation.createReservation(
                 100L, ownerId, 200L,
                 LocalDate.of(2026, 2, 5),
-                LocalTime.of(14, 0),
-                "{}", List.of()
+                LocalTime.of(14, 0), List.of()
         );
         reservation.setStaffId(staffId);
 
@@ -152,8 +150,7 @@ class ReservationServiceConfirmOverlapRollbackIntegrationTest {
         Reservation reservation = Reservation.createReservation(
                 100L, ownerId, 200L,
                 LocalDate.of(2026, 2, 5),
-                LocalTime.of(14, 0),
-                "{}", List.of()
+                LocalTime.of(14, 0), List.of()
         );
         reservation.setStaffId(staffId);
 

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceConfirmTimeBlockUnitTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceConfirmTimeBlockUnitTest.java
@@ -80,8 +80,7 @@ class ReservationServiceConfirmTimeBlockUnitTest {
         Reservation reservation = Reservation.createReservation(
                 100L, ownerId, 200L,
                 LocalDate.of(2026, 2, 5),
-                LocalTime.of(14, 0),
-                "{}", List.of()
+                LocalTime.of(14, 0), List.of()
         );
         reservation.setStaffId(staffId);
         reservation.setStartAt(LocalDateTime.of(2026, 2, 5, 14, 0));
@@ -127,8 +126,7 @@ class ReservationServiceConfirmTimeBlockUnitTest {
         Reservation reservation = Reservation.createReservation(
                 100L, ownerId, 200L,
                 LocalDate.of(2026, 2, 5),
-                LocalTime.of(14, 0),
-                "{}", List.of()
+                LocalTime.of(14, 0), List.of()
         );
         reservation.setStaffId(staffId);
         reservation.setStartAt(LocalDateTime.of(2026, 2, 5, 14, 0));

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceCreateReservationNewFieldsUnitTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceCreateReservationNewFieldsUnitTest.java
@@ -1,0 +1,112 @@
+package com.example.easybooking.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.easybooking.reservation.ReservationReader;
+import com.example.easybooking.reservation.ReservationTimeBlockWriter;
+import com.example.easybooking.reservation.ReservationWriter;
+import com.example.easybooking.reservation.TimeBlockGenerator;
+import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.reservation.dto.ReservationCreateRequest;
+import com.example.easybooking.reservation.dto.ReservationResponse;
+import com.example.easybooking.shop.ShopReader;
+import com.example.easybooking.shop.domain.Shop;
+import com.example.easybooking.staff.StaffReader;
+import com.example.easybooking.staff.domain.Staff;
+import com.example.easybooking.user.UserReader;
+import com.example.easybooking.user.domain.User;
+import com.example.easybooking.user.domain.UserType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceCreateReservationNewFieldsUnitTest {
+
+    @Mock ReservationWriter reservationWriter;
+    @Mock ReservationReader reservationReader;
+    @Mock UserReader userReader;
+    @Mock ShopReader shopReader;
+    @Mock StaffReader staffReader;
+    @Mock ApplicationEventPublisher eventPublisher;
+    @Mock TimeBlockGenerator timeBlockGenerator;
+    @Mock ReservationTimeBlockWriter reservationTimeBlockWriter;
+    @Mock ReservationMenuItemService reservationMenuItemService;
+    @Mock ReservationMenuInputValueService reservationMenuInputValueService;
+    @Mock com.example.easybooking.reservation.ReservationMenuItemReader menuItemReader;
+    @Mock com.example.easybooking.reservation.ReservationMenuInputValueReader inputValueReader;
+
+    private ReservationService reservationService;
+
+    @BeforeEach
+    void setUp() {
+        reservationService = new ReservationService(
+                reservationWriter, reservationReader, userReader, shopReader, staffReader,
+                new ObjectMapper(), eventPublisher, timeBlockGenerator,
+                reservationTimeBlockWriter, reservationMenuItemService, reservationMenuInputValueService,
+                menuItemReader, inputValueReader
+        );
+    }
+
+    @Test
+    void createReservation_worksWithExplicitFieldsOnly_withoutFormData() {
+        long customerUserId = 200L;
+        long shopId = 1L;
+        long staffId = 10L;
+
+        ReservationCreateRequest request = new ReservationCreateRequest();
+        request.setShopId(shopId);
+        request.setStaffId(staffId);
+        request.setDate(LocalDate.of(2026, 3, 20));
+        request.setTime(LocalTime.of(10, 0));
+        request.setRequirements("new-contract");
+        request.setImageUrls(List.of("https://img/a.jpg", "https://img/b.jpg"));
+
+        Shop shop = mock(Shop.class);
+        when(shop.getOwnerId()).thenReturn(100L);
+        when(shopReader.read(shopId)).thenReturn(shop);
+
+        Staff staff = mock(Staff.class);
+        when(staff.getShopId()).thenReturn(shopId);
+        when(staffReader.read(staffId)).thenReturn(staff);
+
+        when(userReader.read(customerUserId)).thenReturn(
+                User.createUser("provider-customer", "고객", "010", UserType.CUSTOMER)
+        );
+
+        when(reservationWriter.save(any(Reservation.class))).thenAnswer(invocation -> {
+            Reservation reservation = invocation.getArgument(0);
+            var idField = Reservation.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(reservation, 999L);
+            return reservation;
+        });
+
+        ReservationResponse response = reservationService.createReservation(request, customerUserId);
+
+        ArgumentCaptor<Reservation> captor = ArgumentCaptor.forClass(Reservation.class);
+        verify(reservationWriter).save(captor.capture());
+        Reservation saved = captor.getValue();
+
+        assertThat(saved.getDate()).isEqualTo(LocalDate.of(2026, 3, 20));
+        assertThat(saved.getTime()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(saved.getDesignImageURLs()).hasSize(2);
+
+        assertThat(response.getDate()).isEqualTo(LocalDate.of(2026, 3, 20));
+        assertThat(response.getTime()).isEqualTo(LocalTime.of(10, 0));
+        assertThat(response.getRequests()).isEqualTo("new-contract");
+        assertThat(response.getPhotoCount()).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceCreateReservationStaffIdValidationTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceCreateReservationStaffIdValidationTest.java
@@ -21,7 +21,8 @@ import com.example.easybooking.user.UserReader;
 import com.example.easybooking.user.domain.User;
 import com.example.easybooking.user.domain.UserType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Map;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -69,10 +70,8 @@ class ReservationServiceCreateReservationStaffIdValidationTest {
         ReservationCreateRequest request = new ReservationCreateRequest();
         request.setShopId(shopId);
         request.setStaffId(staffId);
-        request.setFormData(Map.of(
-                "date", "2026-02-05",
-                "time", "14:00"
-        ));
+        request.setDate(LocalDate.of(2026, 2, 5));
+        request.setTime(LocalTime.of(14, 0));
 
         Shop shop = mock(Shop.class);
         when(shop.getOwnerId()).thenReturn(ownerUserId);
@@ -101,10 +100,8 @@ class ReservationServiceCreateReservationStaffIdValidationTest {
         ReservationCreateRequest request = new ReservationCreateRequest();
         request.setShopId(shopId);
         request.setStaffId(null);
-        request.setFormData(Map.of(
-                "date", "2026-02-05",
-                "time", "14:00"
-        ));
+        request.setDate(LocalDate.of(2026, 2, 5));
+        request.setTime(LocalTime.of(14, 0));
 
         Shop shop = mock(Shop.class);
         when(shop.getOwnerId()).thenReturn(ownerUserId);
@@ -124,10 +121,8 @@ class ReservationServiceCreateReservationStaffIdValidationTest {
         ReservationCreateRequest request = new ReservationCreateRequest();
         request.setShopId(shopId);
         request.setStaffId(staffId);
-        request.setFormData(Map.of(
-                "date", "2026-02-05",
-                "time", "14:00"
-        ));
+        request.setDate(LocalDate.of(2026, 2, 5));
+        request.setTime(LocalTime.of(14, 0));
 
         Shop shop = mock(Shop.class);
         when(shop.getOwnerId()).thenReturn(ownerUserId);
@@ -149,10 +144,8 @@ class ReservationServiceCreateReservationStaffIdValidationTest {
         ReservationCreateRequest request = new ReservationCreateRequest();
         request.setShopId(shopId);
         request.setStaffId(staffId);
-        request.setFormData(Map.of(
-                "date", "2026-02-05",
-                "time", "14:00"
-        ));
+        request.setDate(LocalDate.of(2026, 2, 5));
+        request.setTime(LocalTime.of(14, 0));
 
         Shop shop = mock(Shop.class);
         when(shop.getOwnerId()).thenReturn(ownerUserId);
@@ -174,10 +167,8 @@ class ReservationServiceCreateReservationStaffIdValidationTest {
         ReservationCreateRequest request = new ReservationCreateRequest();
         request.setShopId(shopId);
         request.setStaffId(staffId);
-        request.setFormData(Map.of(
-                "date", "2026-02-05",
-                "time", "14:11"
-        ));
+        request.setDate(LocalDate.of(2026, 2, 5));
+        request.setTime(LocalTime.of(14, 11));
 
         Shop shop = mock(Shop.class);
         when(shop.getOwnerId()).thenReturn(ownerUserId);

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceDualWriteTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceDualWriteTest.java
@@ -29,9 +29,9 @@ import com.example.easybooking.user.UserReader;
 import com.example.easybooking.user.domain.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
-import java.util.HashMap;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,11 +72,8 @@ class ReservationServiceDualWriteTest {
         ReservationCreateRequest request = new ReservationCreateRequest();
         request.setShopId(1L);
         request.setStaffId(10L);
-
-        Map<String, String> formData = new HashMap<>();
-        formData.put("date", "2026-02-11");
-        formData.put("time", "14:00");
-        request.setFormData(formData);
+        request.setDate(LocalDate.of(2026, 2, 11));
+        request.setTime(LocalTime.of(14, 0));
         request.setMenuSelections(menuSelections);
         return request;
     }
@@ -107,7 +104,7 @@ class ReservationServiceDualWriteTest {
         });
     }
 
-    // 4-E-1: formDataJson + 새 테이블 동시 저장
+    // 4-E-1: reservations + 새 테이블 동시 저장
     @Test
     void createReservation_savesFormDataJsonAndMenuItems() {
         setupCommonMocks();

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetCustomerReservationInChatUnitTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetCustomerReservationInChatUnitTest.java
@@ -85,13 +85,11 @@ class ReservationServiceGetCustomerReservationInChatUnitTest {
 
         Reservation r1 = Reservation.createReservation(
                 shopId, 100L, customerId,
-                LocalDate.parse("2026-01-10"), LocalTime.parse("10:00"),
-                formJson, List.of()
+                LocalDate.parse("2026-01-10"), LocalTime.parse("10:00"), List.of()
         );
         Reservation r2 = Reservation.createReservation(
                 shopId, 100L, customerId,
-                LocalDate.parse("2026-01-11"), LocalTime.parse("11:00"),
-                formJson, List.of()
+                LocalDate.parse("2026-01-11"), LocalTime.parse("11:00"), List.of()
         );
 
         when(reservationReader.findByCustomerIdAndShopId(customerId, shopId)).thenReturn(List.of(r1, r2));
@@ -114,4 +112,5 @@ class ReservationServiceGetCustomerReservationInChatUnitTest {
         verify(reservationReader, never()).findByCustomerId(anyLong());
     }
 }
+
 

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetDetailMenuResponseTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetDetailMenuResponseTest.java
@@ -71,8 +71,6 @@ class ReservationServiceGetDetailMenuResponseTest {
         when(r.getCustomerId()).thenReturn(customerId);
         when(r.getOwnerUserId()).thenReturn(ownerUserId);
         when(r.getShopId()).thenReturn(shopId);
-        when(r.getFormDataJson()).thenReturn(
-                "{\"part\":\"손\",\"removal\":\"예\",\"requests\":\"요청\",\"extend\":\"0\",\"wrapping\":\"0\"}");
         when(r.getDesignImageURLs()).thenReturn(List.of());
         when(r.getDate()).thenReturn(LocalDate.of(2026, 2, 11));
         when(r.getTime()).thenReturn(LocalTime.of(14, 0));
@@ -159,8 +157,8 @@ class ReservationServiceGetDetailMenuResponseTest {
     // --- 5-A-2 ---
 
     @Test
-    @DisplayName("5-A-2: reservation_menu_items 데이터가 없으면 formDataJson fallback")
-    void getReservationDetail_fallsBackToFormDataJson_whenNoMenuItems() {
+    @DisplayName("5-A-2: reservation_menu_items 데이터가 없으면 menus는 빈 리스트를 반환한다")
+    void getReservationDetail_returnsEmptyMenus_whenNoMenuItems() {
         // given
         Long reservationId = 2L;
         Long customerId = 20L;
@@ -175,12 +173,7 @@ class ReservationServiceGetDetailMenuResponseTest {
         // when
         ReservationDetailResponse result = reservationService.getReservationDetail(reservationId, customerId);
 
-        // then: formDataJson 기반 필드가 정상 반환
-        assertThat(result.getPart()).isEqualTo("손");
-        assertThat(result.getRemoval()).isEqualTo("예");
-        assertThat(result.getRequests()).isEqualTo("요청");
-
-        // then: menus는 빈 리스트
+        // then
         assertThat(result.getMenus()).isEmpty();
     }
 

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetMyReservationsUnitTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetMyReservationsUnitTest.java
@@ -84,18 +84,15 @@ class ReservationServiceGetMyReservationsUnitTest {
 
         Reservation r1 = Reservation.createReservation(
                 1L, 100L, customerId,
-                LocalDate.parse("2026-01-10"), LocalTime.parse("10:00"),
-                formJson, List.of()
+                LocalDate.parse("2026-01-10"), LocalTime.parse("10:00"), List.of()
         );
         Reservation r2 = Reservation.createReservation(
                 2L, 200L, customerId,
-                LocalDate.parse("2026-01-11"), LocalTime.parse("11:00"),
-                formJson, List.of()
+                LocalDate.parse("2026-01-11"), LocalTime.parse("11:00"), List.of()
         );
         Reservation r3 = Reservation.createReservation(
                 1L, 100L, customerId,
-                LocalDate.parse("2026-01-12"), LocalTime.parse("12:00"),
-                formJson, List.of()
+                LocalDate.parse("2026-01-12"), LocalTime.parse("12:00"), List.of()
         );
 
         when(reservationReader.findByCustomerId(customerId)).thenReturn(List.of(r1, r2, r3));
@@ -128,4 +125,5 @@ class ReservationServiceGetMyReservationsUnitTest {
         verify(shopReader, never()).read(anyLong());
     }
 }
+
 

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetReservationsByCustomerInShopUnitTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetReservationsByCustomerInShopUnitTest.java
@@ -88,13 +88,11 @@ class ReservationServiceGetReservationsByCustomerInShopUnitTest {
 
         Reservation r1 = Reservation.createReservation(
                 shopId, ownerId, customerId,
-                LocalDate.parse("2026-01-10"), LocalTime.parse("10:00"),
-                formJson, List.of()
+                LocalDate.parse("2026-01-10"), LocalTime.parse("10:00"), List.of()
         );
         Reservation r2 = Reservation.createReservation(
                 shopId, ownerId, customerId,
-                LocalDate.parse("2026-01-11"), LocalTime.parse("11:00"),
-                formJson, List.of()
+                LocalDate.parse("2026-01-11"), LocalTime.parse("11:00"), List.of()
         );
         when(reservationReader.findByShopIdAndCustomerId(shopId, customerId)).thenReturn(List.of(r1, r2));
 
@@ -113,4 +111,5 @@ class ReservationServiceGetReservationsByCustomerInShopUnitTest {
         verify(reservationReader, times(1)).findByShopIdAndCustomerId(shopId, customerId);
     }
 }
+
 

--- a/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetShopReservationUnitTest.java
+++ b/src/test/java/com/example/easybooking/reservation/service/ReservationServiceGetShopReservationUnitTest.java
@@ -85,18 +85,15 @@ class ReservationServiceGetShopReservationUnitTest {
 
         Reservation r1 = Reservation.createReservation(
                 100L, ownerId, customer1Id,
-                LocalDate.parse("2026-01-10"), LocalTime.parse("10:00"),
-                formJson, List.of()
+                LocalDate.parse("2026-01-10"), LocalTime.parse("10:00"), List.of()
         );
         Reservation r2 = Reservation.createReservation(
                 100L, ownerId, customer2Id,
-                LocalDate.parse("2026-01-11"), LocalTime.parse("11:00"),
-                formJson, List.of()
+                LocalDate.parse("2026-01-11"), LocalTime.parse("11:00"), List.of()
         );
         Reservation r3 = Reservation.createReservation(
                 100L, ownerId, customer1Id,
-                LocalDate.parse("2026-01-12"), LocalTime.parse("12:00"),
-                formJson, List.of()
+                LocalDate.parse("2026-01-12"), LocalTime.parse("12:00"), List.of()
         );
 
         when(reservationReader.findByShopIdIn(List.of(100L))).thenReturn(List.of(r1, r2, r3));
@@ -140,4 +137,5 @@ class ReservationServiceGetShopReservationUnitTest {
         verify(reservationReader, never()).findByCustomerId(anyLong());
     }
 }
+
 


### PR DESCRIPTION
## Summary
- 문제/목표:
  - 예약 생성 API가 레거시 `formData`에 의존하던 구조에서 벗어나, 명시 필드(`date`, `time`, `requirements`, `imageUrls`) 기반 계약으로 일원화한다.
  - `formData` 누락 시 발생 가능한 500/NPE 위험을 제거하고, 문서/코드/테스트 계약을 동일하게 맞춘다.
- 대안:
  - A안: `formData` 유지 + null-safe 보완
  - B안(선택): `formData` 제거 + 신규 명시 필드 계약으로 즉시 전환
- 선택 이유:
  - 레거시 경로를 남기면 계약 이중화로 회귀 포인트가 늘어나므로, 단일 계약으로 전환하는 편이 운영/연동 리스크가 낮다.

## Changes
- 예약 생성 계약을 `formData`에서 명시 필드(`date/time/requirements/imageUrls`) 중심으로 전환.
- 레거시 경로 정리: 서비스/DTO/엔티티의 `formData`/`formDataJson` 의존 제거 및 응답 계약 정리.
- DB/문서 정합화: Flyway 컬럼 제거(`V6`) 및 API 명세(`api/03`, `api/04`)를 신규 스키마로 동기화.

## Test plan
- TDD 문서:
  - `docs/issues/#105/04-tdd/plan.md`
- 확인한 테스트 (체크리스트):
  - [x] 레거시 `formData` 요청 거부(4xx) 계약 고정
  - [x] `date/time` 필수값 검증(4xx) 고정
  - [x] 신규 필드 기반 예약 생성 성공 경로 검증
  - [x] `formData` 의존 제거 후 회귀(500) 방지 확인
  - [x] 문서 정합화 항목(6-1, 6-2) 완료 반영
- 실행 결과 (work-log 기준):
  - `./gradlew compileJava compileTestJava` 성공
  - `ReservationServiceCreateReservationNewFieldsUnitTest` 성공
  - `ReservationServiceDualWriteTest` 성공
  - `ReservationChatPublishIntegrationTest` 성공
  - 예약 조회/상세 관련 단위테스트 묶음 성공
- 엣지 케이스/회귀 포인트:
  - 레거시 payload 재유입 시 500이 아닌 4xx 유지
  - Flyway 적용 환경에서 `form_data_json` 제거 후 런타임 영향 점검
  - 클라이언트 요청 계약(`date/time`) 누락 회귀 방지



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reservation creation now uses explicit fields (date, time, requirements, imageUrls); legacy free-form form data removed from responses.
* **Tests**
  * Test suite updated and expanded to validate the new reservation creation flow and input validations.
* **Chores**
  * Database migration removes the legacy form-data column.
* **Documentation**
  * Added comprehensive user flows and API specs for onboarding, availability, and reservation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->