### PR TITLE
fix : Update shop menu service test constructor usage

### DIFF
--- a/docs/issues/#125/03-implementation/0001-worklog.md
+++ b/docs/issues/#125/03-implementation/0001-worklog.md
@@ -51,3 +51,15 @@
   - 이후 `.\gradlew.bat compileJava` 재실행 통과
 - 다음 작업:
   - 프론트에서 `menu.tags` 기반 수정 모달 초기값 적용
+
+## 2026-05-02
+
+- 작업 단위: CI `compileTestJava` 실패 수정
+- 변경 내용:
+  - `ShopMenuManagementServiceTest`에서 변경된 서비스 생성자에 맞춰 `ShopMenuTagRepository` 주입 추가
+- 이유:
+  - `ShopMenuManagementService` 생성자에 `ShopMenuTagRepository`가 추가되면서 기존 테스트 생성 코드가 컴파일되지 않았음
+- 검증:
+  - `.\gradlew.bat build` 통과
+- 다음 작업:
+  - GitHub Actions 재실행 결과 확인

--- a/src/test/java/com/example/easybooking/shop/service/ShopMenuManagementServiceTest.java
+++ b/src/test/java/com/example/easybooking/shop/service/ShopMenuManagementServiceTest.java
@@ -9,6 +9,7 @@ import com.example.easybooking.shop.dto.request.CreateShopMenuRequest;
 import com.example.easybooking.shop.dto.request.UpdateShopMenuRequest;
 import com.example.easybooking.shop.dto.response.ShopMenuResponse;
 import com.example.easybooking.shop.repository.ShopMenuRepository;
+import com.example.easybooking.shop.repository.ShopMenuTagRepository;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,9 @@ class ShopMenuManagementServiceTest {
     @Autowired
     ShopMenuRepository shopMenuRepository;
 
+    @Autowired
+    ShopMenuTagRepository shopMenuTagRepository;
+
     ShopMenuManagementService service;
 
     @BeforeEach
@@ -28,7 +32,7 @@ class ShopMenuManagementServiceTest {
         shopMenuRepository.deleteAll();
         ShopMenuReader reader = new ShopMenuReader(shopMenuRepository);
         ShopMenuWriter writer = new ShopMenuWriter(shopMenuRepository);
-        service = new ShopMenuManagementService(reader, writer);
+        service = new ShopMenuManagementService(reader, writer, shopMenuTagRepository);
     }
 
     @Test


### PR DESCRIPTION
## Background / Why This Issue

- `#126` merge 이후 `ShopMenuManagementService` 생성자 인자가 `ShopMenuTagRepository`를 포함하도록 바뀌었습니다.
- 기존 `ShopMenuManagementServiceTest`가 이전 생성자 시그니처를 사용해 `compileTestJava`에서 실패했습니다.

## Summary

- `ShopMenuManagementServiceTest`에 `ShopMenuTagRepository` 주입을 추가했습니다.
- 테스트의 서비스 생성 코드를 현재 생성자 시그니처에 맞췄습니다.
- `docs/issues/#125/03-implementation/0001-worklog.md`에 CI 수정 기록을 추가했습니다.

## Testing

- `./gradlew.bat build`

## Risks

- 테스트 생성자 사용만 맞춘 변경이라 런타임 동작 변경은 없습니다.

## Related Issue

- Follow-up for #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved continuous integration test compilation failure by updating test configuration.

* **Documentation**
  * Updated worklog documenting implementation progress and completed fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->