### PR TITLE
feat: 예약 시스템 메시지 누락 복구

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
@@ -48,4 +50,8 @@ dependencies {
     implementation 'software.amazon.awssdk:protocol-core:2.20.0'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
 }

--- a/src/main/java/com/example/easybooking/chat/MessageReader.java
+++ b/src/main/java/com/example/easybooking/chat/MessageReader.java
@@ -38,6 +38,16 @@ public class MessageReader {
         return messages;
     }
 
+    public List<Message> readMessagesAfter(ChatRoom chatRoom, Long afterMessageId, int size, Long userId) {
+        List<Message> messages = messageRepository.findMessagesAfter(chatRoom.getId(), afterMessageId, size);
+        if (!messages.isEmpty()) {
+            Long lastMessageId = messages.get(messages.size() - 1).getId();
+            chatRoom.updateLastReadMessageId(lastMessageId, userId);
+            chatRoomRepository.save(chatRoom);
+        }
+        return messages;
+    }
+
 
     public int countUnreadMessages(Long chatRoomId, Long lastReadMessageId, Long userId) {
         return messageRepository.countUnreadMessages(chatRoomId, lastReadMessageId, userId);

--- a/src/main/java/com/example/easybooking/chat/SystemMessageWriter.java
+++ b/src/main/java/com/example/easybooking/chat/SystemMessageWriter.java
@@ -8,6 +8,7 @@ import com.example.easybooking.chat.dto.response.MessageResponse;
 import com.example.easybooking.chat.repository.MessageRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
@@ -19,7 +20,7 @@ public class SystemMessageWriter {
     private final MessageRepository messageRepository;
     private final ChatRoomReader chatRoomReader;
 
-    @Transactional
+    @Transactional(propagation = Propagation.MANDATORY)
     public MessageResponse saveReservationMessage(
             Long chatRoomId,
             Long reservationId,

--- a/src/main/java/com/example/easybooking/chat/presentation/MesssageController.java
+++ b/src/main/java/com/example/easybooking/chat/presentation/MesssageController.java
@@ -21,10 +21,17 @@ public class MesssageController {
     public ResponseEntity<List<MessageResponse>> getMessageHistory(
             @PathVariable Long chatRoomId,
             @RequestParam(required = false) Long cursor,
+            @RequestParam(required = false) Long afterMessageId,
             @RequestParam(defaultValue = "50") int size,
             @RequireAuthenticatedUser AuthenticatedUser user) {
         return ResponseEntity.ok(
-                messageService.getMessageHistory(chatRoomId, user.getUserId(), cursor, size)
+                messageService.getMessageHistory(
+                        chatRoomId,
+                        user.getUserId(),
+                        cursor,
+                        afterMessageId,
+                        size
+                )
         );
     }
 

--- a/src/main/java/com/example/easybooking/chat/repository/MessageRepository.java
+++ b/src/main/java/com/example/easybooking/chat/repository/MessageRepository.java
@@ -36,6 +36,15 @@ public interface MessageRepository extends JpaRepository<Message,Long> {
             @Param("cursorId") Long cursorId,
             @Param("size") int size);
 
+    @Query("SELECT m FROM Message m " +
+            "WHERE m.chatRoomId = :chatRoomId " +
+            "AND m.id > :afterMessageId " +
+            "ORDER BY m.id ASC LIMIT :size")
+    List<Message> findMessagesAfter(
+            @Param("chatRoomId") Long chatRoomId,
+            @Param("afterMessageId") Long afterMessageId,
+            @Param("size") int size);
+
     void deleteByChatRoomId(Long chatRoomId);
     void deleteBySenderId(Long senderId);
 }

--- a/src/main/java/com/example/easybooking/chat/service/MessageService.java
+++ b/src/main/java/com/example/easybooking/chat/service/MessageService.java
@@ -5,7 +5,9 @@ import com.example.easybooking.chat.MessageReader;
 import com.example.easybooking.chat.domain.ChatRoom;
 import com.example.easybooking.chat.domain.Message;
 import com.example.easybooking.chat.dto.response.MessageResponse;
+import com.example.easybooking.errors.errorcode.ChatErrorCode;
 import com.example.easybooking.errors.errorcode.ChatRoomErrorCode;
+import com.example.easybooking.errors.exception.ChatException;
 import com.example.easybooking.errors.exception.ChatRoomException;
 import com.example.easybooking.user.UserReader;
 import java.util.HashMap;
@@ -25,10 +27,14 @@ public class MessageService {
             Long chatRoomId,
             Long userId,
             Long cursor,
+            Long afterMessageId,
             int size) {
         ChatRoom chatRoom = chatRoomReader.read(chatRoomId);
         if (!chatRoom.isParticipant(userId)) {
             throw new ChatRoomException(ChatRoomErrorCode.CHAT_PARTICIPANT_REQUIRED);
+        }
+        if (cursor != null && afterMessageId != null) {
+            throw new ChatException(ChatErrorCode.MESSAGE_CURSOR_CONFLICT);
         }
 
         String ownerName = userReader.read(chatRoom.getOwnerId()).getName();
@@ -38,7 +44,9 @@ public class MessageService {
         nameMap.put(chatRoom.getOwnerId(), ownerName);
         nameMap.put(chatRoom.getCustomerId(), customerName);
 
-        List<Message> messages = messageReader.readMessages(chatRoom, cursor, size, userId);
+        List<Message> messages = afterMessageId == null
+                ? messageReader.readMessages(chatRoom, cursor, size, userId)
+                : messageReader.readMessagesAfter(chatRoom, afterMessageId, size, userId);
 
         return messages.stream()
                 .map(m -> MessageResponse.from(m, nameMap.getOrDefault(m.getSenderId(), "알 수 없음")))

--- a/src/main/java/com/example/easybooking/errors/errorcode/ChatErrorCode.java
+++ b/src/main/java/com/example/easybooking/errors/errorcode/ChatErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ChatErrorCode implements ErrorCode {
     MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 메시지입니다."),
-    MESSAGE_CONTENT_INVALID(HttpStatus.BAD_REQUEST, "메시지 내용이 올바르지 않습니다.");
+    MESSAGE_CONTENT_INVALID(HttpStatus.BAD_REQUEST, "메시지 내용이 올바르지 않습니다."),
+    MESSAGE_CURSOR_CONFLICT(HttpStatus.BAD_REQUEST, "cursor와 afterMessageId는 동시에 사용할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/example/easybooking/reservation/event/ReservationChatEventListener.java
+++ b/src/main/java/com/example/easybooking/reservation/event/ReservationChatEventListener.java
@@ -1,17 +1,16 @@
 package com.example.easybooking.reservation.event;
 
 import com.example.easybooking.chat.ChatRoomWriter;
-import com.example.easybooking.chat.ChatTopicPublisher;
 import com.example.easybooking.chat.SystemMessageWriter;
 import com.example.easybooking.chat.domain.ChatRoom;
 import com.example.easybooking.chat.dto.response.MessageResponse;
 import com.example.easybooking.chat.repository.ChatRoomRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
@@ -19,10 +18,10 @@ public class ReservationChatEventListener {
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomWriter chatRoomWriter;
     private final SystemMessageWriter systemMessageWriter;
-    private final ChatTopicPublisher chatTopicPublisher;
+    private final ApplicationEventPublisher eventPublisher;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @EventListener
+    @Transactional(propagation = Propagation.MANDATORY)
     public void onReservationEvent(ReservationEvent event) {
         ChatRoom chatRoom = chatRoomRepository
                 .findByShopIdAndCustomerId(event.shopId(), event.customerId())
@@ -37,6 +36,6 @@ public class ReservationChatEventListener {
                 event.messageType()
         );
 
-        chatTopicPublisher.publishToRoom(chatRoom.getId(), msg);
+        eventPublisher.publishEvent(new ReservationMessageSavedEvent(chatRoom.getId(), msg));
     }
 }

--- a/src/main/java/com/example/easybooking/reservation/event/ReservationChatPublishListener.java
+++ b/src/main/java/com/example/easybooking/reservation/event/ReservationChatPublishListener.java
@@ -1,0 +1,29 @@
+package com.example.easybooking.reservation.event;
+
+import com.example.easybooking.chat.ChatTopicPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationChatPublishListener {
+    private final ChatTopicPublisher chatTopicPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onReservationMessageSaved(ReservationMessageSavedEvent event) {
+        try {
+            chatTopicPublisher.publishToRoom(event.chatRoomId(), event.message());
+        } catch (RuntimeException e) {
+            log.error(
+                    "예약 시스템 메시지 웹소켓 발행 실패 chatRoomId={} messageId={}",
+                    event.chatRoomId(),
+                    event.message().getMessageId(),
+                    e
+            );
+        }
+    }
+}

--- a/src/main/java/com/example/easybooking/reservation/event/ReservationMessageSavedEvent.java
+++ b/src/main/java/com/example/easybooking/reservation/event/ReservationMessageSavedEvent.java
@@ -1,0 +1,9 @@
+package com.example.easybooking.reservation.event;
+
+import com.example.easybooking.chat.dto.response.MessageResponse;
+
+public record ReservationMessageSavedEvent(
+        Long chatRoomId,
+        MessageResponse message
+) {
+}

--- a/src/test/java/com/example/easybooking/ReservationMessageDeliveryIntegrationTest.java
+++ b/src/test/java/com/example/easybooking/ReservationMessageDeliveryIntegrationTest.java
@@ -1,0 +1,194 @@
+package com.example.easybooking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+
+import com.example.easybooking.chat.ChatTopicPublisher;
+import com.example.easybooking.chat.domain.Message;
+import com.example.easybooking.chat.domain.MessageType;
+import com.example.easybooking.chat.dto.response.MessageResponse;
+import com.example.easybooking.chat.repository.ChatRoomRepository;
+import com.example.easybooking.chat.repository.MessageRepository;
+import com.example.easybooking.chat.service.MessageService;
+import com.example.easybooking.errors.errorcode.ChatErrorCode;
+import com.example.easybooking.errors.exception.ChatException;
+import com.example.easybooking.reservation.domain.Reservation;
+import com.example.easybooking.reservation.domain.repository.ReservationRepository;
+import com.example.easybooking.reservation.dto.ReservationCreateRequest;
+import com.example.easybooking.reservation.dto.ReservationResponse;
+import com.example.easybooking.reservation.service.ReservationService;
+import com.example.easybooking.shop.dto.request.CreateShopRequest;
+import com.example.easybooking.shop.service.ShopService;
+import com.example.easybooking.staff.repository.StaffRepository;
+import com.example.easybooking.user.domain.User;
+import com.example.easybooking.user.domain.UserType;
+import com.example.easybooking.user.domain.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+class ReservationMessageDeliveryIntegrationTest {
+
+    @MockitoBean
+    private ChatTopicPublisher chatTopicPublisher;
+
+    @Autowired private ReservationService reservationService;
+    @Autowired private MessageService messageService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private ShopService shopService;
+    @Autowired private StaffRepository staffRepository;
+    @Autowired private ChatRoomRepository chatRoomRepository;
+    @Autowired private MessageRepository messageRepository;
+    @Autowired private ReservationRepository reservationRepository;
+
+    @BeforeEach
+    void resetPublisher() {
+        reset(chatTopicPublisher);
+    }
+
+    @Test
+    void 예약과_시스템메시지를_커밋한_뒤_웹소켓을_발행한다() {
+        Fixture fixture = createFixture();
+
+        ReservationResponse response = reservationService.createReservation(
+                createReservationRequest(fixture.shopId(), fixture.staffId()),
+                fixture.customerId()
+        );
+
+        Reservation reservation = reservationRepository.findById(response.getId()).orElseThrow();
+        var chatRoom = chatRoomRepository
+                .findByShopIdAndCustomerId(fixture.shopId(), fixture.customerId())
+                .orElseThrow();
+        Message message = findReservationMessage(reservation.getId());
+
+        assertThat(message.getMessageType()).isEqualTo(MessageType.RESERVATION_CREATED);
+        assertThat(message.getChatRoomId()).isEqualTo(chatRoom.getId());
+        verify(chatTopicPublisher).publishToRoom(
+                eq(chatRoom.getId()),
+                argThat(payload -> payload instanceof MessageResponse messageResponse
+                        && reservation.getId().equals(messageResponse.getReservationId())
+                        && message.getId().equals(messageResponse.getMessageId()))
+        );
+    }
+
+    @Test
+    void 웹소켓_발행이_실패해도_예약과_시스템메시지는_유지한다() {
+        Fixture fixture = createFixture();
+        doThrow(new IllegalStateException("websocket unavailable"))
+                .when(chatTopicPublisher)
+                .publishToRoom(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any());
+
+        ReservationResponse response = reservationService.createReservation(
+                createReservationRequest(fixture.shopId(), fixture.staffId()),
+                fixture.customerId()
+        );
+
+        assertThat(reservationRepository.findById(response.getId())).isPresent();
+        assertThat(findReservationMessage(response.getId()).getMessageType())
+                .isEqualTo(MessageType.RESERVATION_CREATED);
+    }
+
+    @Test
+    void 마지막_수신_ID_이후_메시지를_오름차순으로_조회한다() {
+        Fixture fixture = createFixture();
+        ReservationResponse response = reservationService.createReservation(
+                createReservationRequest(fixture.shopId(), fixture.staffId()),
+                fixture.customerId()
+        );
+        Message systemMessage = findReservationMessage(response.getId());
+
+        Message second = messageRepository.saveAndFlush(
+                Message.create(systemMessage.getChatRoomId(), fixture.ownerId(), "두 번째")
+        );
+        Message third = messageRepository.saveAndFlush(
+                Message.create(systemMessage.getChatRoomId(), fixture.customerId(), "세 번째")
+        );
+
+        List<MessageResponse> messages = messageService.getMessageHistory(
+                systemMessage.getChatRoomId(),
+                fixture.customerId(),
+                null,
+                systemMessage.getId(),
+                50
+        );
+
+        assertThat(messages).extracting(MessageResponse::getMessageId)
+                .containsExactly(second.getId(), third.getId());
+    }
+
+    @Test
+    void 과거와_이후_커서를_동시에_요청하면_거부한다() {
+        Fixture fixture = createFixture();
+        ReservationResponse response = reservationService.createReservation(
+                createReservationRequest(fixture.shopId(), fixture.staffId()),
+                fixture.customerId()
+        );
+        Message systemMessage = findReservationMessage(response.getId());
+
+        assertThatThrownBy(() -> messageService.getMessageHistory(
+                systemMessage.getChatRoomId(),
+                fixture.customerId(),
+                systemMessage.getId(),
+                systemMessage.getId(),
+                50
+        )).isInstanceOfSatisfying(ChatException.class, exception ->
+                assertThat(exception.getErrorCode()).isEqualTo(ChatErrorCode.MESSAGE_CURSOR_CONFLICT));
+    }
+
+    private Message findReservationMessage(Long reservationId) {
+        return messageRepository.findAll().stream()
+                .filter(message -> reservationId.equals(message.getReservationId()))
+                .findFirst()
+                .orElseThrow();
+    }
+
+    private Fixture createFixture() {
+        String suffix = UUID.randomUUID().toString();
+        User owner = userRepository.save(User.createUser(
+                "owner-" + suffix,
+                "점주",
+                "01000000000",
+                UserType.OWNER
+        ));
+        User customer = userRepository.save(User.createUser(
+                "customer-" + suffix,
+                "고객",
+                "01011111111",
+                UserType.CUSTOMER
+        ));
+
+        CreateShopRequest shopRequest = CreateShopRequest.builder()
+                .businessName("매장-" + suffix)
+                .address("테스트 주소")
+                .businessNumber(suffix.substring(0, 12))
+                .build();
+        Long shopId = shopService.createShop(owner.getId(), shopRequest).getShopId();
+        Long staffId = staffRepository.findFirstByShopIdOrderByIdAsc(shopId).orElseThrow().getId();
+        return new Fixture(owner.getId(), customer.getId(), shopId, staffId);
+    }
+
+    private ReservationCreateRequest createReservationRequest(Long shopId, Long staffId) {
+        ReservationCreateRequest request = new ReservationCreateRequest();
+        request.setShopId(shopId);
+        request.setStaffId(staffId);
+        request.setDate(LocalDate.of(2027, 1, 10));
+        request.setTime(LocalTime.of(14, 10));
+        request.setImageUrls(List.of());
+        return request;
+    }
+
+    private record Fixture(Long ownerId, Long customerId, Long shopId, Long staffId) {
+    }
+}

--- a/src/test/java/com/example/easybooking/ReservationMessageRollbackIntegrationTest.java
+++ b/src/test/java/com/example/easybooking/ReservationMessageRollbackIntegrationTest.java
@@ -1,0 +1,104 @@
+package com.example.easybooking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.example.easybooking.chat.ChatTopicPublisher;
+import com.example.easybooking.chat.SystemMessageWriter;
+import com.example.easybooking.chat.domain.ReservationChangeSnapshot;
+import com.example.easybooking.reservation.domain.repository.ReservationRepository;
+import com.example.easybooking.reservation.dto.ReservationCreateRequest;
+import com.example.easybooking.reservation.service.ReservationService;
+import com.example.easybooking.shop.dto.request.CreateShopRequest;
+import com.example.easybooking.shop.service.ShopService;
+import com.example.easybooking.staff.repository.StaffRepository;
+import com.example.easybooking.user.domain.User;
+import com.example.easybooking.user.domain.UserType;
+import com.example.easybooking.user.domain.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+class ReservationMessageRollbackIntegrationTest {
+
+    @MockitoBean private SystemMessageWriter systemMessageWriter;
+    @MockitoBean private ChatTopicPublisher chatTopicPublisher;
+
+    @Autowired private ReservationService reservationService;
+    @Autowired private ReservationRepository reservationRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private ShopService shopService;
+    @Autowired private StaffRepository staffRepository;
+
+    @Test
+    void 시스템메시지_저장이_실패하면_예약도_롤백한다() {
+        Fixture fixture = createFixture();
+        long reservationCountBefore = reservationRepository.count();
+        when(systemMessageWriter.saveReservationMessage(
+                anyLong(),
+                anyLong(),
+                nullable(Integer.class),
+                nullable(String.class),
+                nullable(ReservationChangeSnapshot.class),
+                any()
+        )).thenThrow(new IllegalStateException("message persistence failed"));
+
+        assertThatThrownBy(() -> reservationService.createReservation(
+                createReservationRequest(fixture.shopId(), fixture.staffId()),
+                fixture.customerId()
+        )).isInstanceOf(IllegalStateException.class)
+                .hasMessage("message persistence failed");
+
+        assertThat(reservationRepository.count()).isEqualTo(reservationCountBefore);
+        verifyNoInteractions(chatTopicPublisher);
+    }
+
+    private Fixture createFixture() {
+        String suffix = UUID.randomUUID().toString();
+        User owner = userRepository.save(User.createUser(
+                "rollback-owner-" + suffix,
+                "점주",
+                "01022222222",
+                UserType.OWNER
+        ));
+        User customer = userRepository.save(User.createUser(
+                "rollback-customer-" + suffix,
+                "고객",
+                "01033333333",
+                UserType.CUSTOMER
+        ));
+
+        CreateShopRequest shopRequest = CreateShopRequest.builder()
+                .businessName("롤백 매장-" + suffix)
+                .address("테스트 주소")
+                .businessNumber(suffix.substring(0, 12))
+                .build();
+        Long shopId = shopService.createShop(owner.getId(), shopRequest).getShopId();
+        Long staffId = staffRepository.findFirstByShopIdOrderByIdAsc(shopId).orElseThrow().getId();
+        return new Fixture(customer.getId(), shopId, staffId);
+    }
+
+    private ReservationCreateRequest createReservationRequest(Long shopId, Long staffId) {
+        ReservationCreateRequest request = new ReservationCreateRequest();
+        request.setShopId(shopId);
+        request.setStaffId(staffId);
+        request.setDate(LocalDate.of(2027, 1, 10));
+        request.setTime(LocalTime.of(14, 10));
+        request.setImageUrls(List.of());
+        return request;
+    }
+
+    private record Fixture(Long customerId, Long shopId, Long staffId) {
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,40 @@
+spring:
+  application:
+    name: easybooking-test
+  flyway:
+    enabled: false
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+  kakao:
+    auth:
+      client: test-client-id
+      redirect: http://localhost:8080/oauth/login/kakao
+      redirect-local: http://localhost:5173/auth
+
+aws:
+  s3:
+    bucket: test-bucket
+    base-url: https://test-bucket.s3.amazonaws.com
+    access-key: test-access-key
+    secret-key: test-secret-key
+
+jwt:
+  secret: test-secret-key-for-testing-purposes-only-must-be-at-least-32-chars-long
+  access-token-expiration: 3600000
+  refresh-token-expiration: 604800000
+
+springdoc:
+  api-docs:
+    enabled: false
+
+server-url: http://localhost:8080
+frontend-base-url: http://localhost:5173


### PR DESCRIPTION
## #️⃣ Issue Number

- #136

## 📝 요약(Summary)

- 예약 변경과 시스템 메시지 저장을 하나의 트랜잭션으로 묶었습니다.
- 웹소켓 발행을 트랜잭션 커밋 이후로 분리했습니다.
- 메시지 ID 커서를 이용한 HTTP 누락 복구 API를 추가했습니다.

## 🛠️ PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정

## 📸스크린샷 (선택)

- 프론트 PR에서 연결 상태 UI와 함께 확인할 수 있습니다.

## 💬 공유사항 to 리뷰어

- 시스템 메시지 저장은 기존 예약 트랜잭션에 참여하며, 저장 실패 시 예약 변경도 롤백됩니다.
- 웹소켓 발행 실패는 커밋된 예약과 메시지를 롤백하지 않습니다.
- `afterMessageId`는 해당 채팅방에 존재하는 메시지여야 하며, 이후 메시지를 오름차순으로 반환합니다.

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] `./gradlew check`를 통과했습니다.
- [x] 웹소켓 단절 중 예약 변경 후 재연결 HTTP 복구 E2E를 확인했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading chat history after a specific message, enabling forward pagination.
  * Reservation-related chat messages are now published reliably after successful saves.

* **Bug Fixes**
  * Requests combining cursor-based and after-message pagination now return a clear validation error.
  * Reservation creation is rolled back when its chat message cannot be saved, preventing inconsistent data.

* **Tests**
  * Added coverage for chat delivery, pagination, publication failures, and transaction rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->