### PR TITLE
feat: 사용자 이름·전화번호 수정 API 추가

### DIFF
--- a/src/main/java/com/example/easybooking/user/domain/User.java
+++ b/src/main/java/com/example/easybooking/user/domain/User.java
@@ -46,6 +46,11 @@ public class User {
          return user;
     }
 
+    public void updateProfile(String name, String phoneNumber) {
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+    }
+
     public enum Role {
         USER, ADMIN
     }

--- a/src/main/java/com/example/easybooking/user/dto/UpdateUserProfileRequest.java
+++ b/src/main/java/com/example/easybooking/user/dto/UpdateUserProfileRequest.java
@@ -1,0 +1,22 @@
+package com.example.easybooking.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateUserProfileRequest {
+
+    @NotBlank(message = "이름은 필수입니다.")
+    @Size(max = 20, message = "이름은 20자를 초과할 수 없습니다.")
+    private String name;
+
+    @NotBlank(message = "전화번호는 필수입니다.")
+    @Pattern(regexp = "^01[016789]\\d{7,8}$", message = "올바른 휴대전화 번호를 입력해주세요.")
+    private String phoneNumber;
+}

--- a/src/main/java/com/example/easybooking/user/presentation/UserController.java
+++ b/src/main/java/com/example/easybooking/user/presentation/UserController.java
@@ -9,11 +9,14 @@ import com.example.easybooking.user.dto.CustomerSignUpResponse;
 import com.example.easybooking.user.dto.OwnerSignUpRequest;
 import com.example.easybooking.user.dto.OwnerSignUpResponse;
 import com.example.easybooking.user.dto.UserResponse;
+import com.example.easybooking.user.dto.UpdateUserProfileRequest;
 import com.example.easybooking.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,6 +32,15 @@ public class UserController {
     public ResponseEntity<UserResponse> getMyInfo(
             @RequireAuthenticatedUser AuthenticatedUser authenticatedUser) {
         UserResponse response = userService.getUserInfo(authenticatedUser.getUserId());
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<UserResponse> updateMyInfo(
+            @RequireAuthenticatedUser AuthenticatedUser authenticatedUser,
+            @Valid @RequestBody UpdateUserProfileRequest request
+    ) {
+        UserResponse response = userService.updateUserProfile(authenticatedUser.getUserId(), request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/easybooking/user/service/UserService.java
+++ b/src/main/java/com/example/easybooking/user/service/UserService.java
@@ -14,6 +14,7 @@ import com.example.easybooking.user.dto.CustomerSignUpResponse;
 import com.example.easybooking.user.dto.OwnerSignUpRequest;
 import com.example.easybooking.user.dto.OwnerSignUpResponse;
 import com.example.easybooking.user.dto.UserResponse;
+import com.example.easybooking.user.dto.UpdateUserProfileRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,6 +47,13 @@ public class UserService {
 
     public UserResponse getUserInfo(Long userId) {
         User user = userReader.read(userId);
+        return UserResponse.from(user);
+    }
+
+    @Transactional
+    public UserResponse updateUserProfile(Long userId, UpdateUserProfileRequest request) {
+        User user = userReader.read(userId);
+        user.updateProfile(request.getName().trim(), request.getPhoneNumber());
         return UserResponse.from(user);
     }
 

--- a/src/test/java/com/example/easybooking/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/easybooking/user/service/UserServiceTest.java
@@ -1,0 +1,62 @@
+package com.example.easybooking.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.example.easybooking.auth.util.JwtUtil;
+import com.example.easybooking.user.UserReader;
+import com.example.easybooking.user.UserWriter;
+import com.example.easybooking.user.domain.User;
+import com.example.easybooking.user.domain.UserType;
+import com.example.easybooking.user.dto.UpdateUserProfileRequest;
+import com.example.easybooking.user.dto.UserResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserWriter userWriter;
+
+    @Mock
+    private UserReader userReader;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    void updateUserProfileChangesNameAndPhoneNumber() {
+        User user = User.createUser("provider-id", "이전 이름", "01011112222", UserType.CUSTOMER);
+        when(userReader.read(1L)).thenReturn(user);
+
+        UserResponse response = userService.updateUserProfile(
+                1L,
+                new UpdateUserProfileRequest("새 이름", "01033334444")
+        );
+
+        assertThat(response.getName()).isEqualTo("새 이름");
+        assertThat(response.getPhoneNumber()).isEqualTo("01033334444");
+        assertThat(user.getName()).isEqualTo("새 이름");
+        assertThat(user.getPhoneNumber()).isEqualTo("01033334444");
+    }
+
+    @Test
+    void updateUserProfileTrimsName() {
+        User user = User.createUser("provider-id", "이전 이름", "01011112222", UserType.OWNER);
+        when(userReader.read(2L)).thenReturn(user);
+
+        UserResponse response = userService.updateUserProfile(
+                2L,
+                new UpdateUserProfileRequest("  새 이름  ", "01055556666")
+        );
+
+        assertThat(response.getName()).isEqualTo("새 이름");
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 인증 사용자용 PATCH /user/me API를 추가했습니다.
- 이름과 휴대전화 번호 입력값을 검증합니다.
- 프로필 변경 서비스 테스트를 추가했습니다.

## 검증
- bash gradlew check

Closes #139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability for authenticated users to update their profile name and mobile phone number.
  * Profile updates validate required fields, enforce name length limits, and check Korean mobile phone formats.
  * Names are automatically trimmed before being saved and displayed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->